### PR TITLE
Replace deprecated cfe refs, #6

### DIFF
--- a/fsw/src/sch_lab_app.c
+++ b/fsw/src/sch_lab_app.c
@@ -72,7 +72,7 @@ void SCH_Lab_AppMain(void)
     int              i;
     int32            rtnStat;
     uint32           SCH_OneHzPktsRcvd = 0;
-    uint32           RunStatus = CFE_ES_APP_RUN;
+    uint32           RunStatus = CFE_ES_RunStatus_APP_RUN;
     CFE_SB_PipeId_t  SCH_CmdPipe;
 
     CFE_ES_PerfLogEntry(SCH_MAIN_TASK_PERF_ID);
@@ -88,7 +88,7 @@ void SCH_Lab_AppMain(void)
          {   
               CFE_SB_InitMsg(&SCH_CmdHeaderTable[i],
                               SCH_LAB_ScheduleTable[i].MessageID,
-                                sizeof(CFE_SB_CmdHdr_t), TRUE);
+                                sizeof(CFE_SB_CmdHdr_t), true);
          } 
          else
          {
@@ -116,7 +116,7 @@ void SCH_Lab_AppMain(void)
                 SCH_LAB_MISSION_REV);    
 
     /* Loop Forever */
-    while (CFE_ES_RunLoop(&RunStatus) == TRUE)
+    while (CFE_ES_RunLoop(&RunStatus) == true)
     {
         CFE_ES_PerfLogExit(SCH_MAIN_TASK_PERF_ID);
 


### PR DESCRIPTION
Fixes #6

Submitted by @skliper , CLA on file

Testing:
- make ENABLE_UNIT_TESTS=TRUE SIMULATION=native prep
- Built on linux with -DCFE_OMIT_DEPRECATED_6_6 with no build errors
- make test passed (except osal_timer_UT which occasionally fails on linux)
- cFS executes and loads apps with no issues