### PR TITLE
Fix #18: Include definition of CFE_SB_MsgId_t

### DIFF
--- a/fsw/platform_inc/sch_lab_sched_tab.h
+++ b/fsw/platform_inc/sch_lab_sched_tab.h
@@ -30,6 +30,7 @@
 *************************************************************************/
 
 
+#include "cfe_sb_extern_typedefs.h"  /* for CFE_SB_MsgId_t */
 #include "cfe_msgids.h"
 
 /*


### PR DESCRIPTION
This type is provided by the cfe_sb_extern_typedefs.h file,
so the table definition should include this header.

**Describe the contribution**
Fixes issue #18
Add explicit inclusion of cfe_sb_extern_typedefs.h, which provides the definition of the `CFE_SB_MsgId_t` type.

**Testing performed**
Compile all code in the CFS bundle

**Expected behavior changes**
Build no longer fails due to unknown type when integrating the `ic-ccb-20191009` branch.

**System(s) tested on:**
Ubuntu 18.04.2 LTS, 64 bit (build host)

**Contributor Info**
Joseph Hickey, Vantage Systems Inc.
