### PR TITLE
Accept CFE_SUCCESS from CFE_TBL_GetAddress()

### DIFF
--- a/fsw/src/sch_lab_app.c
+++ b/fsw/src/sch_lab_app.c
@@ -182,7 +182,8 @@ int32 SCH_LAB_AppInit(void)
     ** Get Table Address
     */ 
     Status = CFE_TBL_GetAddress((void **)&MySchTBL, TblHandles);
-    if ( Status != CFE_TBL_INFO_UPDATED )
+    if ( Status != CFE_SUCCESS &&
+         Status != CFE_TBL_INFO_UPDATED )
     {
         CFE_ES_WriteToSysLog("SCHEULE APP: Error Getting Table's Address \
                               SCH_LAB_SchTbl, RC = 0x%08X\n", Status);


### PR DESCRIPTION
**Describe the contribution**

Fix #24 

CFE_SUCCESS is a valid return from the CFE_TBL_GetAddress() call. It should not be rejected as an error.

**Testing performed**
Build for RTEMS, sanity check that SCH_LAB starts and runs normally.

**Expected behavior changes**
Adhere to the documented behavior/return codes of the CFE_TBL_GetAddress() call

**System(s) tested on:**
i686-rtems4.11 target running in QEMU.

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
