### PR TITLE
Fix #34, Build fails with deprecated cFE/OSAL elements removed

### DIFF
--- a/fsw/src/sch_lab_app.c
+++ b/fsw/src/sch_lab_app.c
@@ -62,7 +62,7 @@ void SCH_Lab_AppMain(void)
     int              i;
     uint32           SCH_OneHzPktsRcvd = 0;
     uint32           Status = CFE_SUCCESS;
-    uint32           RunStatus = CFE_ES_APP_RUN;
+    uint32           RunStatus = CFE_ES_RunStatus_APP_RUN;
 
     CFE_ES_PerfLogEntry(SCH_MAIN_TASK_PERF_ID);
 
@@ -87,7 +87,7 @@ void SCH_Lab_AppMain(void)
     }  
 
     /* Loop Forever */
-    while (CFE_ES_RunLoop(&RunStatus) == TRUE)
+    while (CFE_ES_RunLoop(&RunStatus) == true)
     {
         CFE_ES_PerfLogExit(SCH_MAIN_TASK_PERF_ID);
 
@@ -199,7 +199,7 @@ int32 SCH_LAB_AppInit(void)
          {   
               CFE_SB_InitMsg(&SCH_CmdHeaderTable[i],
                               MySchTBL->MessageID[i],
-                              sizeof(CFE_SB_CmdHdr_t), TRUE);
+                              sizeof(CFE_SB_CmdHdr_t), true);
          } 
          else
          {


### PR DESCRIPTION
Describe the contribution
Fixes #35, Build fails with deprecated cFE/OSAL elements removed

Testing performed
Nominal build process:

    make distclean
    make prep
    make
    make install
    followed by building with OMIT_DEPRECATED = true
    make distclean
    make OMIT_DEPRECATED=true prep
    make
    make install

Confirmed clean build in both cases.

Expected behavior changes
Clean build when OMIT_DEPRECATED = true

System(s) tested on
Oracle VM VirtualBox
OS: ubuntu-18.04.3
Versions: cFE 6.7.5.0, OSAL 5.0.5.0, PSP 1.4.3.0

Additional context
There is a total of three pull requests to address issue_35:
nasa/to_lab
nasa/sample_app
nasa/sch_lab

All three are intended to be delivered together.

Contributor Info
Dan Knutsen
GSFC/NASA