### PR TITLE
General SCH_LAB cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,6 @@ include_directories(${ci_lab_MISSION_DIR}/fsw/platform_inc)
 include_directories(${to_lab_MISSION_DIR}/fsw/platform_inc)
 include_directories(${sample_app_MISSION_DIR}/fsw/platform_inc)
 
-aux_source_directory(fsw/src APP_SRC_FILES)
-
 # Create the app module
-add_cfe_app(sch_lab ${APP_SRC_FILES})
+add_cfe_app(sch_lab fsw/src/sch_lab_app.c)
 add_cfe_tables(sch_lab_table fsw/src/sch_lab_table.c)

--- a/fsw/platform_inc/sch_lab_sched_tab.h
+++ b/fsw/platform_inc/sch_lab_sched_tab.h
@@ -61,15 +61,13 @@
 */
 typedef struct
 {
-    CFE_SB_MsgId_t  MessageID[SCH_LAB_MAX_SCHEDULE_ENTRIES];  /* Message ID for the table entry */
-    uint32          PacketRate[SCH_LAB_MAX_SCHEDULE_ENTRIES]; /* Rate: Send packet every N seconds */
-    uint32          Counter[SCH_LAB_MAX_SCHEDULE_ENTRIES];    /* Counter used to send packet */
-     
+    CFE_SB_MsgId_t  MessageID;  /* Message ID for the table entry */
+    uint32          PacketRate; /* Rate: Send packet every N seconds */
+} SCH_LAB_ScheduleTableEntry_t;
+
+
+typedef struct
+{
+    SCH_LAB_ScheduleTableEntry_t Config[SCH_LAB_MAX_SCHEDULE_ENTRIES];
 } SCH_LAB_ScheduleTable_t;
 
-/*
-** Local Function Prototypes
-*/
-
-int32 SCH_LAB_TblValidation(void *MySchTBL);
-int32 SCH_LAB_AppInit(void);

--- a/fsw/src/sch_lab_app.c
+++ b/fsw/src/sch_lab_app.c
@@ -57,9 +57,15 @@ typedef union
 
 typedef struct
 {
-    SCH_LAB_MessageBuffer_t  MsgBuf[SCH_LAB_MAX_SCHEDULE_ENTRIES];
+    SCH_LAB_MessageBuffer_t MsgBuf;
+    uint32                  PacketRate;
+    uint32                  Counter;
+} SCH_LAB_StateEntry_t;
+
+typedef struct
+{
+    SCH_LAB_StateEntry_t     State[SCH_LAB_MAX_SCHEDULE_ENTRIES];
     CFE_TBL_Handle_t         TblHandle;
-    SCH_LAB_ScheduleTable_t  *MySchTBL;
 
     CFE_SB_Msg_t             *CmdPipePktPtr;
     CFE_SB_PipeId_t          CmdPipe;
@@ -73,6 +79,11 @@ SCH_LAB_GlobalData_t    SCH_LAB_Global;
 
 
 /*
+** Local Function Prototypes
+*/
+int32 SCH_LAB_AppInit(void);
+
+/*
 ** AppMain
 */
 void SCH_Lab_AppMain(void)
@@ -81,6 +92,7 @@ void SCH_Lab_AppMain(void)
     uint32           SCH_OneHzPktsRcvd = 0;
     uint32           Status = CFE_SUCCESS;
     uint32           RunStatus = CFE_ES_RunStatus_APP_RUN;
+    SCH_LAB_StateEntry_t *LocalStateEntry;
 
     CFE_ES_PerfLogEntry(SCH_MAIN_TASK_PERF_ID);
 
@@ -94,18 +106,6 @@ void SCH_Lab_AppMain(void)
 
     } 
    
-    /*
-    ** Manage Table 
-    */
-    Status = CFE_TBL_Manage(SCH_LAB_Global.TblHandle);
-    if ( Status != CFE_SUCCESS )
-    {
-        CFE_ES_WriteToSysLog("SCH_LAB: Error managing table  RC = 0x%08lX\n",
-                (unsigned long)Status);
-        CFE_TBL_ReleaseAddress(SCH_LAB_Global.TblHandle);
-
-    }  
-
     /* Loop Forever */
     while (CFE_ES_RunLoop(&RunStatus) == true)
     {
@@ -122,50 +122,40 @@ void SCH_Lab_AppMain(void)
             /*
             ** Process table every second, sending packets that are ready 
             */
+            LocalStateEntry = SCH_LAB_Global.State;
             for (i = 0; i < SCH_LAB_MAX_SCHEDULE_ENTRIES; i++) 
             {
-                if ( SCH_LAB_Global.MySchTBL->MessageID[i] != SCH_LAB_END_OF_TABLE )
-                { 
-                      SCH_LAB_Global.MySchTBL->Counter[i]++;
-                      if (SCH_LAB_Global.MySchTBL->Counter[i] >= SCH_LAB_Global.MySchTBL->PacketRate[i] )
-                      {
-                          SCH_LAB_Global.MySchTBL->Counter[i] = 0;
-                          CFE_SB_SendMsg(&SCH_LAB_Global.MsgBuf[i].MsgHdr);
-                      }
-                } 
-                else
+                if (LocalStateEntry->PacketRate != 0)
                 {
-                   break;
+                    ++LocalStateEntry->Counter;
+                    if ( LocalStateEntry->Counter >= LocalStateEntry->PacketRate )
+                    {
+                        LocalStateEntry->Counter = 0;
+                        CFE_SB_SendMsg(&LocalStateEntry->MsgBuf.MsgHdr);
+                    }
                 }
+                ++LocalStateEntry;
             }
         }
 
     }/* end while */
     
-    /*
-    ** Release the table
-    */
-    Status = CFE_TBL_ReleaseAddress(SCH_LAB_Global.TblHandle);
-    if ( Status != CFE_SUCCESS )
-    {
-        CFE_ES_WriteToSysLog("SCH_LAB: Error Releasing Table SCH_LAB_SchTbl, RC = 0x%08lX\n",
-                              (unsigned long)Status);
-
-    }
-
     CFE_ES_ExitApp( Status );
     
 }/* end SCH_Lab_AppMain */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */ 
 /*                                                                 */ 
-/* SCH_LAB_AppInit() -- initialization                                     */ 
+/* SCH_LAB_AppInit() -- initialization                             */
 /*                                                                 */ 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 int32 SCH_LAB_AppInit(void)
 { 
     int              i;
     int32            Status;
+    SCH_LAB_ScheduleTable_t *ConfigTable;
+    SCH_LAB_ScheduleTableEntry_t *ConfigEntry;
+    SCH_LAB_StateEntry_t *LocalStateEntry;
 
     memset(&SCH_LAB_Global, 0, sizeof(SCH_LAB_Global));
 
@@ -176,7 +166,8 @@ int32 SCH_LAB_AppInit(void)
                               "SCH_LAB_SchTbl",
                               sizeof(SCH_LAB_ScheduleTable_t), 
                               CFE_TBL_OPT_DEFAULT, 
-                              &SCH_LAB_TblValidation);
+                              NULL);
+
     if ( Status != CFE_SUCCESS )
     {
         CFE_ES_WriteToSysLog("SCH_LAB: Error Registering SCH_LAB_SchTbl, RC = 0x%08lX\n",
@@ -203,7 +194,7 @@ int32 SCH_LAB_AppInit(void)
     /*
     ** Get Table Address
     */ 
-    Status = CFE_TBL_GetAddress((void **)&SCH_LAB_Global.MySchTBL, SCH_LAB_Global.TblHandle);
+    Status = CFE_TBL_GetAddress((void **)&ConfigTable, SCH_LAB_Global.TblHandle);
     if ( Status != CFE_SUCCESS &&
          Status != CFE_TBL_INFO_UPDATED )
     {
@@ -216,18 +207,30 @@ int32 SCH_LAB_AppInit(void)
     /*
     ** Initialize the command headers
     */
+    ConfigEntry = ConfigTable->Config;
+    LocalStateEntry = SCH_LAB_Global.State;
     for (i = 0; i < SCH_LAB_MAX_SCHEDULE_ENTRIES; i++) 
     {
-         if ( SCH_LAB_Global.MySchTBL->MessageID[i] != SCH_LAB_END_OF_TABLE )
-         {   
-              CFE_SB_InitMsg(&SCH_LAB_Global.MsgBuf[i].MsgHdr,
-                              SCH_LAB_Global.MySchTBL->MessageID[i],
-                              sizeof(CFE_SB_CmdHdr_t), true);
-         } 
-         else
-         {
-              break;
-         }
+        if (ConfigEntry->PacketRate != 0)
+        {
+            CFE_SB_InitMsg(&LocalStateEntry->MsgBuf.MsgHdr,
+                    CFE_SB_ValueToMsgId(ConfigEntry->MessageID),
+                    sizeof(LocalStateEntry->MsgBuf), true);
+            LocalStateEntry->PacketRate = ConfigEntry->PacketRate;
+        }
+        ++ConfigEntry;
+        ++LocalStateEntry;
+    }
+
+    /*
+    ** Release the table
+    */
+    Status = CFE_TBL_ReleaseAddress(SCH_LAB_Global.TblHandle);
+    if ( Status != CFE_SUCCESS )
+    {
+        CFE_ES_WriteToSysLog("SCH_LAB: Error Releasing Table SCH_LAB_SchTbl, RC = 0x%08lX\n",
+                              (unsigned long)Status);
+
     }
 
     /* Create pipe and subscribe to the 1Hz pkt */
@@ -252,17 +255,4 @@ int32 SCH_LAB_AppInit(void)
     return( CFE_SUCCESS );    
 
 }/*End of AppInit*/
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */ 
-/*                                                                 */ 
-/* SCH_LAB_TblValidation() - Validate Table                             */ 
-/*                                                                 */ 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 SCH_LAB_TblValidation(void *MySchTBL)
-{
-
-    /*Write Validation Code Here*/
-
-    return( CFE_SUCCESS );
-}/*End of SchTblValidation*/
 

--- a/fsw/src/sch_lab_app.c
+++ b/fsw/src/sch_lab_app.c
@@ -49,9 +49,15 @@
 /*
 ** Global Structure
 */
+typedef union
+{
+    CFE_SB_Msg_t            MsgHdr;
+    CFE_SB_CmdHdr_t         CommandHeader;
+} SCH_LAB_MessageBuffer_t;
+
 typedef struct
 {
-    CFE_SB_CmdHdr_t          CmdHeaderTable[SCH_LAB_MAX_SCHEDULE_ENTRIES];
+    SCH_LAB_MessageBuffer_t  MsgBuf[SCH_LAB_MAX_SCHEDULE_ENTRIES];
     CFE_TBL_Handle_t         TblHandle;
     SCH_LAB_ScheduleTable_t  *MySchTBL;
 
@@ -124,7 +130,7 @@ void SCH_Lab_AppMain(void)
                       if (SCH_LAB_Global.MySchTBL->Counter[i] >= SCH_LAB_Global.MySchTBL->PacketRate[i] )
                       {
                           SCH_LAB_Global.MySchTBL->Counter[i] = 0;
-                          CFE_SB_SendMsg((CFE_SB_MsgPtr_t)&SCH_LAB_Global.CmdHeaderTable[i]);
+                          CFE_SB_SendMsg(&SCH_LAB_Global.MsgBuf[i].MsgHdr);
                       }
                 } 
                 else
@@ -214,7 +220,7 @@ int32 SCH_LAB_AppInit(void)
     {
          if ( SCH_LAB_Global.MySchTBL->MessageID[i] != SCH_LAB_END_OF_TABLE )
          {   
-              CFE_SB_InitMsg(&SCH_LAB_Global.CmdHeaderTable[i],
+              CFE_SB_InitMsg(&SCH_LAB_Global.MsgBuf[i].MsgHdr,
                               SCH_LAB_Global.MySchTBL->MessageID[i],
                               sizeof(CFE_SB_CmdHdr_t), true);
          } 

--- a/fsw/src/sch_lab_app.c
+++ b/fsw/src/sch_lab_app.c
@@ -30,6 +30,8 @@
 /*
 ** Include Files
 */
+#include <string.h>
+
 #include "cfe.h"
 #include "cfe_sb.h"
 #include "osapi.h"
@@ -45,14 +47,24 @@
 #include "sch_lab_sched_tab.h"
 
 /*
+** Global Structure
+*/
+typedef struct
+{
+    CFE_SB_CmdHdr_t          CmdHeaderTable[SCH_LAB_MAX_SCHEDULE_ENTRIES];
+    CFE_TBL_Handle_t         TblHandle;
+    SCH_LAB_ScheduleTable_t  *MySchTBL;
+
+    CFE_SB_Msg_t             *CmdPipePktPtr;
+    CFE_SB_PipeId_t          CmdPipe;
+
+} SCH_LAB_GlobalData_t;
+
+/*
 ** Global Variables
 */
-CFE_SB_CmdHdr_t          SCH_CmdHeaderTable[SCH_LAB_MAX_SCHEDULE_ENTRIES];
-CFE_TBL_Handle_t         TblHandles;
-SCH_LAB_ScheduleTable_t  *MySchTBL;
+SCH_LAB_GlobalData_t    SCH_LAB_Global;
 
-CFE_SB_Msg_t             *SCH_CmdPipePktPtr;
-CFE_SB_PipeId_t          SCH_CmdPipe;
 
 /*
 ** AppMain
@@ -79,12 +91,12 @@ void SCH_Lab_AppMain(void)
     /*
     ** Manage Table 
     */
-    Status = CFE_TBL_Manage(TblHandles);  
+    Status = CFE_TBL_Manage(SCH_LAB_Global.TblHandle);
     if ( Status != CFE_SUCCESS )
     {
         CFE_ES_WriteToSysLog("SCH_LAB: Error managing table  RC = 0x%08lX\n",
                 (unsigned long)Status);
-        CFE_TBL_ReleaseAddress(TblHandles);
+        CFE_TBL_ReleaseAddress(SCH_LAB_Global.TblHandle);
 
     }  
 
@@ -94,7 +106,7 @@ void SCH_Lab_AppMain(void)
         CFE_ES_PerfLogExit(SCH_MAIN_TASK_PERF_ID);
 
         /* Pend on receipt of 1Hz packet */
-        Status = CFE_SB_RcvMsg(&SCH_CmdPipePktPtr,SCH_CmdPipe,CFE_SB_PEND_FOREVER);
+        Status = CFE_SB_RcvMsg(&SCH_LAB_Global.CmdPipePktPtr,SCH_LAB_Global.CmdPipe,CFE_SB_PEND_FOREVER);
 
         CFE_ES_PerfLogEntry(SCH_MAIN_TASK_PERF_ID);
 
@@ -106,13 +118,13 @@ void SCH_Lab_AppMain(void)
             */
             for (i = 0; i < SCH_LAB_MAX_SCHEDULE_ENTRIES; i++) 
             {
-                if ( MySchTBL->MessageID[i] != SCH_LAB_END_OF_TABLE )
+                if ( SCH_LAB_Global.MySchTBL->MessageID[i] != SCH_LAB_END_OF_TABLE )
                 { 
-                      MySchTBL->Counter[i]++;
-                      if (MySchTBL->Counter[i] >= MySchTBL->PacketRate[i] )
+                      SCH_LAB_Global.MySchTBL->Counter[i]++;
+                      if (SCH_LAB_Global.MySchTBL->Counter[i] >= SCH_LAB_Global.MySchTBL->PacketRate[i] )
                       {
-                          MySchTBL->Counter[i] = 0;
-                          CFE_SB_SendMsg((CFE_SB_MsgPtr_t)&SCH_CmdHeaderTable[i]);
+                          SCH_LAB_Global.MySchTBL->Counter[i] = 0;
+                          CFE_SB_SendMsg((CFE_SB_MsgPtr_t)&SCH_LAB_Global.CmdHeaderTable[i]);
                       }
                 } 
                 else
@@ -127,7 +139,7 @@ void SCH_Lab_AppMain(void)
     /*
     ** Release the table
     */
-    Status = CFE_TBL_ReleaseAddress(TblHandles);
+    Status = CFE_TBL_ReleaseAddress(SCH_LAB_Global.TblHandle);
     if ( Status != CFE_SUCCESS )
     {
         CFE_ES_WriteToSysLog("SCH_LAB: Error Releasing Table SCH_LAB_SchTbl, RC = 0x%08lX\n",
@@ -149,10 +161,12 @@ int32 SCH_LAB_AppInit(void)
     int              i;
     int32            Status;
 
+    memset(&SCH_LAB_Global, 0, sizeof(SCH_LAB_Global));
+
     /*
     ** Register tables with cFE and load default data
     */
-    Status = CFE_TBL_Register(&TblHandles, 
+    Status = CFE_TBL_Register(&SCH_LAB_Global.TblHandle,
                               "SCH_LAB_SchTbl",
                               sizeof(SCH_LAB_ScheduleTable_t), 
                               CFE_TBL_OPT_DEFAULT, 
@@ -169,12 +183,12 @@ int32 SCH_LAB_AppInit(void)
         /*
         ** Loading Table
         */
-        Status = CFE_TBL_Load(TblHandles, CFE_TBL_SRC_FILE, SCH_TBL_DEFAULT_FILE);
+        Status = CFE_TBL_Load(SCH_LAB_Global.TblHandle, CFE_TBL_SRC_FILE, SCH_TBL_DEFAULT_FILE);
         if ( Status != CFE_SUCCESS )
         {
             CFE_ES_WriteToSysLog("SCH_LAB: Error Loading Table SCH_LAB_SchTbl, RC = 0x%08lX\n",
                     (unsigned long)Status);
-            CFE_TBL_ReleaseAddress(TblHandles);
+            CFE_TBL_ReleaseAddress(SCH_LAB_Global.TblHandle);
 
             return ( Status );
         }
@@ -183,7 +197,7 @@ int32 SCH_LAB_AppInit(void)
     /*
     ** Get Table Address
     */ 
-    Status = CFE_TBL_GetAddress((void **)&MySchTBL, TblHandles);
+    Status = CFE_TBL_GetAddress((void **)&SCH_LAB_Global.MySchTBL, SCH_LAB_Global.TblHandle);
     if ( Status != CFE_SUCCESS &&
          Status != CFE_TBL_INFO_UPDATED )
     {
@@ -198,10 +212,10 @@ int32 SCH_LAB_AppInit(void)
     */
     for (i = 0; i < SCH_LAB_MAX_SCHEDULE_ENTRIES; i++) 
     {
-         if ( MySchTBL->MessageID[i] != SCH_LAB_END_OF_TABLE )
+         if ( SCH_LAB_Global.MySchTBL->MessageID[i] != SCH_LAB_END_OF_TABLE )
          {   
-              CFE_SB_InitMsg(&SCH_CmdHeaderTable[i],
-                              MySchTBL->MessageID[i],
+              CFE_SB_InitMsg(&SCH_LAB_Global.CmdHeaderTable[i],
+                              SCH_LAB_Global.MySchTBL->MessageID[i],
                               sizeof(CFE_SB_CmdHdr_t), true);
          } 
          else
@@ -211,13 +225,13 @@ int32 SCH_LAB_AppInit(void)
     }
 
     /* Create pipe and subscribe to the 1Hz pkt */
-    Status = CFE_SB_CreatePipe(&SCH_CmdPipe,8,"SCH_LAB_CMD_PIPE");
+    Status = CFE_SB_CreatePipe(&SCH_LAB_Global.CmdPipe,8,"SCH_LAB_CMD_PIPE");
     if ( Status != CFE_SUCCESS )
     {
        OS_printf("SCH Error creating pipe!\n");
     }
        
-    Status = CFE_SB_Subscribe(CFE_TIME_1HZ_CMD_MID,SCH_CmdPipe);
+    Status = CFE_SB_Subscribe(CFE_TIME_1HZ_CMD_MID,SCH_LAB_Global.CmdPipe);
     if ( Status != CFE_SUCCESS )
     {
        OS_printf("SCH Error subscribing to 1hz!\n");

--- a/fsw/src/sch_lab_table.c
+++ b/fsw/src/sch_lab_table.c
@@ -35,54 +35,25 @@
 
 SCH_LAB_ScheduleTable_t  SCH_TBL_Structure = 
 {
-
-    { 
-        CFE_ES_SEND_HK_MID,
-        CFE_EVS_SEND_HK_MID,
-        CFE_TIME_SEND_HK_MID,
-        CFE_SB_SEND_HK_MID,
-        CFE_TBL_SEND_HK_MID,
-        CI_LAB_SEND_HK_MID,
-        TO_LAB_SEND_HK_MID,
-        SAMPLE_APP_SEND_HK_MID,
-
-        SCH_LAB_END_OF_TABLE          
-    },
-    { /*Packet Rate*/
-        4,  /*ES*/
-        4,  /*EVS*/
-        4,  /*Time*/
-        4,  /*SB*/
-        4,  /*TBL*/
-        4,  /*CI_LAB*/
-        4,  /*TO_LAB*/
-        4,  /*SAMPLE_LAB*/
-        
-        0   /*END OF TABLE*/
-    },
-    {/*Counter*/
-        0,  /*ES*/
-        0,  /*EVS*/
-        0,  /*Time*/
-        0,  /*SB*/
-        0,  /*TBL*/
-        0,  /*CI_LAB*/
-        0,  /*TO_LAB*/
-        0,  /*SAMPLE_LAB*/
-        
-        0   /*END OF TABLE*/
-    } 
-
-    #if 0
-    { SC_SEND_HK_MID,       4, 0 },
-    { SC_1HZ_WAKEUP_MID,    1, 0 },  /* Example of a 1hz packet */
-    { HS_SEND_HK_MID,       4, 0 },
-    { FM_SEND_HK_MID,       4, 0 },
-    { DS_SEND_HK_MID,       4, 0 },
-    { LC_SEND_HK_MID,       4, 0 },
-
-    #endif
-
+        .Config =
+        {
+                { CFE_ES_SEND_HK_MID, 4 },
+                { CFE_EVS_SEND_HK_MID, 4 },
+                { CFE_TIME_SEND_HK_MID, 4 },
+                { CFE_SB_SEND_HK_MID, 4 },
+                { CFE_TBL_SEND_HK_MID, 4 },
+                { CI_LAB_SEND_HK_MID, 4 },
+                { TO_LAB_SEND_HK_MID, 4 },
+                { SAMPLE_APP_SEND_HK_MID, 4 },
+#if 0
+                { SC_SEND_HK_MID,       4, 0 },
+                { SC_1HZ_WAKEUP_MID,    1, 0 },  /* Example of a 1hz packet */
+                { HS_SEND_HK_MID,       4, 0 },
+                { FM_SEND_HK_MID,       4, 0 },
+                { DS_SEND_HK_MID,       4, 0 },
+                { LC_SEND_HK_MID,       4, 0 },
+#endif
+        }
 };
 
 /*


### PR DESCRIPTION
**Describe the contribution**

Fixes #27
Fixes #31
Fixes #32

Applies a consistent naming convention for all symbols in SCH_LAB to be consistent with the published CFE naming convention and other CFE/CFS modules.

Updates the message buffer structures to ensure proper alignment

Changes the table handling as described in #27 

**Testing performed**
Build code with `SIMULATION=native ENABLE_UNIT_TESTS=TRUE` and confirm no errors or warnings in build.  Also build on Raspberry Pi and confirm the cast align warnings are gone.

Execute CFE and confirm nominal operation - all apps load and respond to basic commands as expected.

Test cFS-GroundSystem python app to confirm that telemetry is being sent at the expected intervals.

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 18.04 LTS, 64 bit
Raspberry Pi 3B+

**Additional context**
This single pull requests addresses multiple issues because they cannot be parallelized without introducing conflicts (the latter depends on the former). The fixes are kept as separate commits for review purposes.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.