### PR TITLE
Fix #37, Opaque CFE_SB_MsgId_t values

### DIFF
--- a/fsw/src/sch_lab_app.c
+++ b/fsw/src/sch_lab_app.c
@@ -214,7 +214,7 @@ int32 SCH_LAB_AppInit(void)
         if (ConfigEntry->PacketRate != 0)
         {
             CFE_SB_InitMsg(&LocalStateEntry->MsgBuf.MsgHdr,
-                    CFE_SB_ValueToMsgId(ConfigEntry->MessageID),
+                    ConfigEntry->MessageID,
                     sizeof(LocalStateEntry->MsgBuf), true);
             LocalStateEntry->PacketRate = ConfigEntry->PacketRate;
         }

--- a/fsw/src/sch_lab_table.c
+++ b/fsw/src/sch_lab_table.c
@@ -22,7 +22,7 @@
 
 #include "cfe_tbl_filedef.h"  /* Required to obtain the CFE_TBL_FILEDEF macro definition */
 #include "sch_lab_sched_tab.h" 
-
+#include "cfe_sb.h"           /* Required to use the CFE_SB_MSGID_WRAP_VALUE macro */
 
 /*
 ** SCH Lab schedule table
@@ -37,14 +37,14 @@ SCH_LAB_ScheduleTable_t  SCH_TBL_Structure =
 {
         .Config =
         {
-                { CFE_ES_SEND_HK_MID, 4 },
-                { CFE_EVS_SEND_HK_MID, 4 },
-                { CFE_TIME_SEND_HK_MID, 4 },
-                { CFE_SB_SEND_HK_MID, 4 },
-                { CFE_TBL_SEND_HK_MID, 4 },
-                { CI_LAB_SEND_HK_MID, 4 },
-                { TO_LAB_SEND_HK_MID, 4 },
-                { SAMPLE_APP_SEND_HK_MID, 4 },
+                { CFE_SB_MSGID_WRAP_VALUE(CFE_ES_SEND_HK_MID), 4 },
+                { CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_SEND_HK_MID), 4 },
+                { CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_SEND_HK_MID), 4 },
+                { CFE_SB_MSGID_WRAP_VALUE(CFE_SB_SEND_HK_MID), 4 },
+                { CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_SEND_HK_MID), 4 },
+                { CFE_SB_MSGID_WRAP_VALUE(CI_LAB_SEND_HK_MID), 4 },
+                { CFE_SB_MSGID_WRAP_VALUE(TO_LAB_SEND_HK_MID), 4 },
+                { CFE_SB_MSGID_WRAP_VALUE(SAMPLE_APP_SEND_HK_MID), 4 },
 #if 0
                 { SC_SEND_HK_MID,       4, 0 },
                 { SC_1HZ_WAKEUP_MID,    1, 0 },  /* Example of a 1hz packet */


### PR DESCRIPTION
**Describe the contribution**
Apply the `CFE_SB_MsgIdToValue()` and `CFE_SB_ValueToMsgId()` routines where compatibility with an integer MsgId is necessary - syslog prints, events, compile-time MID `#define` values.

Fixes #37 

**Testing performed**
Unit test
Execute CFE and sanity-check normal operation - send commands to app using `cmdUtil` and confirm commands are processed normally.

**Expected behavior changes**
No impact to behavior.

**System(s) tested on**
Ubuntu 18.04 LTS, 64-bit

**Additional context**
In future versions of CFE SB the MsgId type might not be a simple integer, so this is one step in the direction of avoiding this assumption in apps.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.