### PR TITLE
Fix #56, Apply alignment pattern

### DIFF
--- a/fsw/src/sch_lab_version.h
+++ b/fsw/src/sch_lab_version.h
@@ -31,7 +31,8 @@
 
 /* Development Build Macro Definitions */
 #define SCH_LAB_BUILD_NUMBER 9 /*!< Development Build: Number of commits since baseline */
-#define SCH_LAB_BUILD_BASELINE "v2.4.0-rc1" /*!< Development Build: git tag that is the base for the current development */
+#define SCH_LAB_BUILD_BASELINE \
+    "v2.4.0-rc1" /*!< Development Build: git tag that is the base for the current development */
 
 /* Version Macro Definitions */
 


### PR DESCRIPTION
**Describe the contribution**
Fix #56 

- Use CFE_MSG_CommandHeader_t and CFE_MSG_TelemetryHeader_t in
  command and telemetry type definitions
- Use CFE_SB_TransmitMsg to copy the command and telemetry
  into a CFE_SB_Buffer_t and send it where needed
- Avoids need to create send buffers within the app (or union
  the packet types with CFE_SB_Buffer_t)
- Eliminates references to CFE_SB_CmdHdr_t and CFE_SB_TlmHdr_t
  that formerly enforced alignment since these had potential
  to change the actual packet sizes

**Testing performed**
Bundle CI, unit tests, spot checked cmd/tlm

**Expected behavior changes**
None, pattern applied

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle integration-candidates + nasa/cFE#1015 + #55, and the subject of this PR #56

**Additional context**
Depends on nasa/cFE#1015, #55

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC