### PR TITLE
Fix #80, exit the main loop if init fails

### DIFF
--- a/fsw/src/sch_lab_app.c
+++ b/fsw/src/sch_lab_app.c
@@ -91,6 +91,7 @@ void SCH_Lab_AppMain(void)
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("SCH_LAB: Error Initializing RC = 0x%08lX\n", (unsigned long)Status);
+        RunStatus = CFE_ES_RunStatus_APP_ERROR;
     }
 
     /* Loop Forever */


### PR DESCRIPTION
**Describe the contribution**
Initialize the "RunStatus" to ERROR if initialization fails.  This causes the CFE_ES_RunLoop function to return false, and
the app will exit with an error status.

Fixes #80

**Testing performed**
Build and run CFE with missing SCH LAB table file

**Expected behavior changes**
SCH_LAB exits with error, does not loop infinitely

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
