### PR TITLE
Fixed typos in README and SECURITY docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains NASA's Scheduler Lab (sch_lab), which is a framework co
 
 This lab application is a non-flight packet scheduler application for the cFS Bundle. It is intended to be located in the `apps/sch_lab` subdirectory of a cFS Mission Tree. The Core Flight System is bundled at <https://github.com/nasa/cFS> (which includes sch_lab as a submodule), which includes build and execution instructions.
 
-sch_lab is a simple packet scheduler application with a one second resoluton.
+sch_lab is a simple packet scheduler application with a one second resolution.
 
 To change the list of packets that sch_lab sends out, edit the schedule table located in the platform include file: fsw/platform_inc/sch_lab_sched_tab.h
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ To report a vulnerability for the sch_lab subsystem please [submit an issue](htt
 
 For general cFS vulnerabilities please [open a cFS framework issue](https://github.com/nasa/cfs/issues/new/choose) and see our [top-level security policy](https://github.com/nasa/cFS/security/policy) for additional information.
 
-In either case please use the "Bug Report" template and provide as much information as possible. Apply appropraite labels for each report. For security related reports, tag the issue with the "security" label.
+In either case please use the "Bug Report" template and provide as much information as possible. Apply appropriate labels for each report. For security related reports, tag the issue with the "security" label.
 
 ## Testing
 


### PR DESCRIPTION
**Describe the contribution**
Fixed a couple of minor typos in the _text_ of:
- README.md
- SECURITY.md

**Testing performed**
None (non-executable code).

**Expected behavior changes**
None (Markdown doc changes only).

**System(s) tested on**
n/a

**Additional context**
n/a

**Code contributions**
n/a