### PR TITLE
Fix #85, add CmdCode to sch_lab_table

### DIFF
--- a/fsw/platform_inc/sch_lab_table.h
+++ b/fsw/platform_inc/sch_lab_table.h
@@ -46,8 +46,9 @@
 */
 typedef struct
 {
-    CFE_SB_MsgId_t MessageID;  /* Message ID for the table entry */
-    uint32         PacketRate; /* Rate: Send packet every N seconds */
+    CFE_SB_MsgId_t    MessageID;  /* Message ID for the table entry */
+    uint32            PacketRate; /* Rate: Send packet every N seconds */
+    CFE_MSG_FcnCode_t FcnCode;    /* Command/Function code to set */
 } SCH_LAB_ScheduleTableEntry_t;
 
 typedef struct

--- a/fsw/src/sch_lab_app.c
+++ b/fsw/src/sch_lab_app.c
@@ -196,6 +196,7 @@ int32 SCH_LAB_AppInit(void)
         if (ConfigEntry->PacketRate != 0)
         {
             CFE_MSG_Init(&LocalStateEntry->CmdHeader.Msg, ConfigEntry->MessageID, sizeof(LocalStateEntry->CmdHeader));
+            CFE_MSG_SetFcnCode(&LocalStateEntry->CmdHeader.Msg, ConfigEntry->FcnCode);
             LocalStateEntry->PacketRate = ConfigEntry->PacketRate;
         }
         ++ConfigEntry;

--- a/fsw/tables/sch_lab_table.c
+++ b/fsw/tables/sch_lab_table.c
@@ -50,21 +50,21 @@
 */
 
 SCH_LAB_ScheduleTable_t SCH_TBL_Structure = {.Config = {
-                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_SEND_HK_MID), 4},
-                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_SEND_HK_MID), 4},
-                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_SEND_HK_MID), 4},
-                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_SB_SEND_HK_MID), 4},
-                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_SEND_HK_MID), 4},
-                                                 {CFE_SB_MSGID_WRAP_VALUE(CI_LAB_SEND_HK_MID), 4},
-                                                 {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_SEND_HK_MID), 4},
-                                                 {CFE_SB_MSGID_WRAP_VALUE(SAMPLE_APP_SEND_HK_MID), 4},
+                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_SEND_HK_MID), 4, 0},
+                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_SEND_HK_MID), 4, 0},
+                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_SEND_HK_MID), 4, 0},
+                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_SB_SEND_HK_MID), 4, 0},
+                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_SEND_HK_MID), 4, 0},
+                                                 {CFE_SB_MSGID_WRAP_VALUE(CI_LAB_SEND_HK_MID), 4, 0},
+                                                 {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_SEND_HK_MID), 4, 0},
+                                                 {CFE_SB_MSGID_WRAP_VALUE(SAMPLE_APP_SEND_HK_MID), 4, 0},
 #if 0
-                {CFE_SB_MSGID_WRAP_VALUE(SC_SEND_HK_MID),       4},
-                {CFE_SB_MSGID_WRAP_VALUE(SC_1HZ_WAKEUP_MID),    1},  /* Example of a 1hz packet */
-                {CFE_SB_MSGID_WRAP_VALUE(HS_SEND_HK_MID),       0},  /* Example of a message that wouldn't be sent */
-                {CFE_SB_MSGID_WRAP_VALUE(FM_SEND_HK_MID),       4},
-                {CFE_SB_MSGID_WRAP_VALUE(DS_SEND_HK_MID),       4},
-                {CFE_SB_MSGID_WRAP_VALUE(LC_SEND_HK_MID),       4},
+                {CFE_SB_MSGID_WRAP_VALUE(SC_SEND_HK_MID),       4, 0},
+                {CFE_SB_MSGID_WRAP_VALUE(SC_1HZ_WAKEUP_MID),    1, 0},  /* Example of a 1hz packet */
+                {CFE_SB_MSGID_WRAP_VALUE(HS_SEND_HK_MID),       0, 0},  /* Example of a message that wouldn't be sent */
+                {CFE_SB_MSGID_WRAP_VALUE(FM_SEND_HK_MID),       4, 0},
+                {CFE_SB_MSGID_WRAP_VALUE(DS_SEND_HK_MID),       4, 0},
+                {CFE_SB_MSGID_WRAP_VALUE(LC_SEND_HK_MID),       4, 0},
 #endif
                                              }};
 


### PR DESCRIPTION
**Describe the contribution**
Allows the command/function code to be specified in the messages generated by SCH_LAB.  This allows it to be used for testing apps that require a specific function code in the internal wakeup message.

Fixes #85

**Testing performed**
Validated that the feature works by using it to test BP app (which requires a specific code in it's wakeup MID)

**Expected behavior changes**
SCH_LAB now supports testing apps that require a specific function code in the generated wake up message

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
