### PR TITLE
HotFix 2021-09-07, Fix missing typedef

### DIFF
--- a/fsw/platform_inc/sch_lab_table.h
+++ b/fsw/platform_inc/sch_lab_table.h
@@ -32,6 +32,7 @@
 #define sch_lab_sched_tab_h_
 
 #include "cfe_sb_extern_typedefs.h" /* for CFE_SB_MsgId_t */
+#include "cfe_msg_api_typedefs.h"   /* For CFE_MSG_FcnCode_t */
 #include "cfe_msgids.h"
 
 /*


### PR DESCRIPTION
**Describe the contribution**

See build failure in nasa/cFS#351

https://github.com/nasa/cFS/actions/runs/1214483451

```
[ 82%] Built target sch_lab
[ 82%] Building C object apps/sch_lab/CMakeFiles/cpu1_sch_lab_table_sch_lab_table.dir/fsw/tables/sch_lab_table.c.o
In file included from /home/runner/work/cFS/cFS/apps/sch_lab/fsw/tables/sch_lab_table.c:24:0:
/home/runner/work/cFS/cFS/apps/sch_lab/fsw/platform_inc/sch_lab_table.h:51:5: error: unknown type name ‘CFE_MSG_FcnCode_t’
     CFE_MSG_FcnCode_t FcnCode;    /* Command/Function code to set */
     ^~~~~~~~~~~~~~~~~
make[7]: *** [apps/sch_lab/CMakeFiles/cpu1_sch_lab_table_sch_lab_table.dir/fsw/tables/sch_lab_table.c.o] Error 1
apps/sch_lab/CMakeFiles/cpu1_sch_lab_table_sch_lab_table.dir/build.make:75: recipe for target 'apps/sch_lab/CMakeFiles/cpu1_sch_lab_table_sch_lab_table.dir/fsw/tables/sch_lab_table.c.o' failed
```

**Testing performed**
Works in cFS-bundle fork
https://github.com/astrogeco/cFS/actions/runs/1214618910

**Expected behavior changes**
Clean build

**System(s) tested on**
Ubuntu CI

**Additional context**
Part of nasa/cFS#351

**Third party code**
None