### PR TITLE
Fix #90, apply CFE_SB_ValueToMsgId where required

### DIFF
--- a/fsw/src/sch_lab_app.c
+++ b/fsw/src/sch_lab_app.c
@@ -219,7 +219,7 @@ int32 SCH_LAB_AppInit(void)
         OS_printf("SCH Error creating pipe!\n");
     }
 
-    Status = CFE_SB_Subscribe(CFE_TIME_1HZ_CMD_MID, SCH_LAB_Global.CmdPipe);
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_1HZ_CMD_MID), SCH_LAB_Global.CmdPipe);
     if (Status != CFE_SUCCESS)
     {
         OS_printf("SCH Error subscribing to 1hz!\n");


### PR DESCRIPTION
**Describe the contribution**
Whenever an integer value is used as a CFE_SB_MsgId_t, it should go through the explicit conversion using the supplied inline function.

Fixes #90

**Testing performed**
Build and sanity check CFE

**Expected behavior changes**
Allows SCH_LAB to be built when CFE_SB_MsgId_t is an opaque/non-integer type.
None with default config (where CFE_SB_MsgId_t is an integer type).

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.