### PR TITLE
sch_lab Integration candidate: Caelum+dev1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ To change the list of packets that sch_lab sends out, edit the schedule table lo
 
 ## Version History
 
+### Development Build: v2.5.0-rc4+dev6
+
+- Use separate address variable
+- Use CFE_MSG_PTR conversion macro
+- Update baseline for cFS-Caelum-rc4: v2.5.0-rc4
+- See <https://github.com/nasa/sch_lab/pull/102> and <https://github.com/nasa/cFS/pull/390>
+
 ### Development Build: v2.4.0-rc1+dev53
 
 - Apply CFE_SB_ValueToMsgId where required

--- a/fsw/src/sch_lab_app.c
+++ b/fsw/src/sch_lab_app.c
@@ -144,6 +144,7 @@ int32 SCH_LAB_AppInit(void)
     SCH_LAB_ScheduleTable_t *     ConfigTable;
     SCH_LAB_ScheduleTableEntry_t *ConfigEntry;
     SCH_LAB_StateEntry_t *        LocalStateEntry;
+    void *                        TableAddr;
 
     memset(&SCH_LAB_Global, 0, sizeof(SCH_LAB_Global));
 
@@ -177,7 +178,7 @@ int32 SCH_LAB_AppInit(void)
     /*
     ** Get Table Address
     */
-    Status = CFE_TBL_GetAddress((void **)&ConfigTable, SCH_LAB_Global.TblHandle);
+    Status = CFE_TBL_GetAddress(&TableAddr, SCH_LAB_Global.TblHandle);
     if (Status != CFE_SUCCESS && Status != CFE_TBL_INFO_UPDATED)
     {
         CFE_ES_WriteToSysLog("SCH_LAB: Error Getting Table's Address SCH_LAB_SchTbl, RC = 0x%08lX\n",
@@ -189,6 +190,7 @@ int32 SCH_LAB_AppInit(void)
     /*
     ** Initialize the command headers
     */
+    ConfigTable     = TableAddr;
     ConfigEntry     = ConfigTable->Config;
     LocalStateEntry = SCH_LAB_Global.State;
     for (i = 0; i < SCH_LAB_MAX_SCHEDULE_ENTRIES; i++)

--- a/fsw/src/sch_lab_app.c
+++ b/fsw/src/sch_lab_app.c
@@ -51,7 +51,7 @@
 */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader;
+    CFE_MSG_CommandHeader_t CommandHeader;
     uint32                  PacketRate;
     uint32                  Counter;
 } SCH_LAB_StateEntry_t;
@@ -119,7 +119,7 @@ void SCH_Lab_AppMain(void)
                     if (LocalStateEntry->Counter >= LocalStateEntry->PacketRate)
                     {
                         LocalStateEntry->Counter = 0;
-                        CFE_SB_TransmitMsg(&LocalStateEntry->CmdHeader.Msg, true);
+                        CFE_SB_TransmitMsg(CFE_MSG_PTR(LocalStateEntry->CommandHeader), true);
                     }
                 }
                 ++LocalStateEntry;
@@ -195,8 +195,9 @@ int32 SCH_LAB_AppInit(void)
     {
         if (ConfigEntry->PacketRate != 0)
         {
-            CFE_MSG_Init(&LocalStateEntry->CmdHeader.Msg, ConfigEntry->MessageID, sizeof(LocalStateEntry->CmdHeader));
-            CFE_MSG_SetFcnCode(&LocalStateEntry->CmdHeader.Msg, ConfigEntry->FcnCode);
+            CFE_MSG_Init(CFE_MSG_PTR(LocalStateEntry->CommandHeader), ConfigEntry->MessageID,
+                         sizeof(LocalStateEntry->CommandHeader));
+            CFE_MSG_SetFcnCode(CFE_MSG_PTR(LocalStateEntry->CommandHeader), ConfigEntry->FcnCode);
             LocalStateEntry->PacketRate = ConfigEntry->PacketRate;
         }
         ++ConfigEntry;

--- a/fsw/src/sch_lab_version.h
+++ b/fsw/src/sch_lab_version.h
@@ -30,16 +30,23 @@
  */
 
 /* Development Build Macro Definitions */
-#define SCH_LAB_BUILD_NUMBER 53 /*!< Development Build: Number of commits since baseline */
+#define SCH_LAB_BUILD_NUMBER 6 /*!< Development Build: Number of commits since baseline */
 #define SCH_LAB_BUILD_BASELINE \
-    "v2.4.0-rc1" /*!< Development Build: git tag that is the base for the current development */
+    "v2.5.0-rc4" /*!< Development Build: git tag that is the base for the current development */
 
 /* Version Macro Definitions */
 
 #define SCH_LAB_MAJOR_VERSION 2 /*!< @brief ONLY APPLY for OFFICIAL releases. Major version number. */
 #define SCH_LAB_MINOR_VERSION 3 /*!< @brief ONLY APPLY for OFFICIAL releases. Minor version number. */
 #define SCH_LAB_REVISION      0 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. */
-#define SCH_LAB_MISSION_REV   0 /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
+
+/*!
+ * @brief Mission revision.
+ *
+ * Set to 0 on OFFICIAL releases, and set to 255 (0xFF) on development versions.
+ * Values 1-254 are reserved for mission use to denote patches/customizations as needed.
+ */
+#define SCH_LAB_MISSION_REV 0xFF
 
 #define SCH_LAB_STR_HELPER(x) #x /*!< @brief Helper function to concatenate strings from integer macros */
 #define SCH_LAB_STR(x)        SCH_LAB_STR_HELPER(x) /*!< @brief Helper function to concatenate strings from integer macros */


### PR DESCRIPTION
**Describe the contribution**


PR #94

- Fix #93 
- Updates conversions to CFE_Message_t to use the MSG macro
- This also uses consistent naming - TelemetryHeader rather than TlmHeader

PR #95
- Fix #77, use separate address variable 
- Avoids `(void**)` cast by using a separate `void*` local variable
to hold the address.

**Testing performed**

sch_lab Checks <https://github.com/nasa/sch_lab/pull/102/checks>
cFS Bundle Checks <https://github.com/nasa/cFS/pull/390/checks>

**Expected behavior changes**
See PRs 

**System(s) tested on**
Ubuntu 18.04
RTEMS 4.11
RTEMS 5

**Additional context**
Part of <https://github.com/nasa/cFS/pull/390/>

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
@jphickey 

