### PR TITLE
Fix #120, Remove unnecessary parentheses around return values.

### DIFF
--- a/fsw/src/sch_lab_app.c
+++ b/fsw/src/sch_lab_app.c
@@ -199,7 +199,7 @@ int32 SCH_LAB_AppInit(void)
     {
         CFE_ES_WriteToSysLog("SCH_LAB: Error Registering SCH_LAB_SchTbl, RC = 0x%08lX\n", (unsigned long)Status);
 
-        return (Status);
+        return Status;
     }
     else
     {
@@ -212,7 +212,7 @@ int32 SCH_LAB_AppInit(void)
             CFE_ES_WriteToSysLog("SCH_LAB: Error Loading Table SCH_LAB_SchTbl, RC = 0x%08lX\n", (unsigned long)Status);
             CFE_TBL_ReleaseAddress(SCH_LAB_Global.TblHandle);
 
-            return (Status);
+            return Status;
         }
     }
 
@@ -225,7 +225,7 @@ int32 SCH_LAB_AppInit(void)
         CFE_ES_WriteToSysLog("SCH_LAB: Error Getting Table's Address SCH_LAB_SchTbl, RC = 0x%08lX\n",
                              (unsigned long)Status);
 
-        return (Status);
+        return Status;
     }
 
     /*
@@ -294,6 +294,6 @@ int32 SCH_LAB_AppInit(void)
 
     OS_printf("SCH Lab Initialized.%s\n", SCH_LAB_VERSION_STRING);
 
-    return (CFE_SUCCESS);
+    return CFE_SUCCESS;
 
 } /*End of AppInit*/


### PR DESCRIPTION
**Checklist (Please check before submitting)**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #120 
Removes parentheses in return statements in sch_lab that return a single value/term.
This is aligns these return statements with the predominant style of cFS.

**Testing performed**
None, prior to submission of the pull request.

**Expected behavior changes**
No impact on behavior.

**Contributor Info - All information REQUIRED for consideration of pull request**
@thnkslprpt 