### PR TITLE
Fix #133, Remove component-specific cFE header #includes

### DIFF
--- a/fsw/src/sch_lab_app.c
+++ b/fsw/src/sch_lab_app.c
@@ -27,10 +27,7 @@
 #include <string.h>
 
 #include "cfe.h"
-#include "cfe_sb.h"
 #include "osapi.h"
-#include "cfe_es.h"
-#include "cfe_error.h"
 
 #include "sch_lab_perfids.h"
 #include "sch_lab_version.h"


### PR DESCRIPTION
**Describe the contribution**
- Fixes #133
  - Removes the component-specific cFE headers which are pulled in by the all-inclusive `cfe.h`.

**Testing performed**
Tested with local cFS Build + Run, confirmed successful start-up.

**Expected behavior changes**
None.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)
Current main of the cFS bundle.

**Contributor Info**
Avi Weiss @thnkslprpt