### PR TITLE
Fix #138, adjust table based on apps present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,16 @@ project(CFS_SCH_LAB C)
 
 # These references are specifically needed for the table build
 # it is easiest to add them as directory properties so they won't
-# be considered include directories for SCH_LAB itself.
-include_directories(
-    $<TARGET_PROPERTY:ci_lab,INTERFACE_INCLUDE_DIRECTORIES>
-    $<TARGET_PROPERTY:to_lab,INTERFACE_INCLUDE_DIRECTORIES>
-    $<TARGET_PROPERTY:sample_app,INTERFACE_INCLUDE_DIRECTORIES>
-)
+# be considered include directories for TO_LAB itself.  Each one
+# gets a macro for conditional inclusion in the subscription table.
+foreach(EXT_APP ci_lab to_lab sample_app sc hs lc ds fm)
+  list (FIND TGTSYS_${SYSVAR}_APPS ${EXT_APP} HAVE_APP)
+  if (HAVE_APP GREATER_EQUAL 0)
+    include_directories($<TARGET_PROPERTY:${EXT_APP},INTERFACE_INCLUDE_DIRECTORIES>)
+    string(TOUPPER "HAVE_${EXT_APP}" APP_MACRO)
+    add_definitions(-D${APP_MACRO})
+  endif()
+endforeach()
 
 # Create the app module
 add_cfe_app(sch_lab fsw/src/sch_lab_app.c)

--- a/fsw/tables/sch_lab_table.c
+++ b/fsw/tables/sch_lab_table.c
@@ -23,16 +23,35 @@
 /*
 ** Include headers for message IDs here
 */
+#ifdef HAVE_CI_LAB
 #include "ci_lab_msgids.h"
+#endif
+
+#ifdef HAVE_TO_LAB
 #include "to_lab_msgids.h"
+#endif
 
+#ifdef HAVE_SAMPLE_APP
 #include "sample_app_msgids.h"
+#endif
 
-#if 0
-#include "sc_msgids.h"
+#ifdef HAVE_HS_APP
 #include "hs_msgids.h"
+#endif
+
+#ifdef HAVE_FM_APP
 #include "fm_msgids.h"
+#endif
+
+#ifdef HAVE_SC_APP
+#include "sc_msgids.h"
+#endif
+
+#ifdef HAVE_DS_APP
 #include "ds_msgids.h"
+#endif
+
+#ifdef HAVE_LC_APP
 #include "lc_msgids.h"
 #endif
 
@@ -45,25 +64,40 @@
 **  3. If the table grows too big, increase SCH_LAB_MAX_SCHEDULE_ENTRIES
 */
 
-SCH_LAB_ScheduleTable_t SCH_TBL_Structure = {.TickRate = 1,
-                                             .Config   = {
-                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_SEND_HK_MID), 4, 0},
-                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_SEND_HK_MID), 4, 0},
-                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_SEND_HK_MID), 4, 0},
-                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_SB_SEND_HK_MID), 4, 0},
-                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_SEND_HK_MID), 4, 0},
-                                                 {CFE_SB_MSGID_WRAP_VALUE(CI_LAB_SEND_HK_MID), 4, 0},
-                                                 {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_SEND_HK_MID), 4, 0},
-                                                 {CFE_SB_MSGID_WRAP_VALUE(SAMPLE_APP_SEND_HK_MID), 4, 0},
-#if 0
-                {CFE_SB_MSGID_WRAP_VALUE(SC_SEND_HK_MID),       4, 0},
-                {CFE_SB_MSGID_WRAP_VALUE(SC_1HZ_WAKEUP_MID),    1, 0},  /* Example of a 1hz packet */
-                {CFE_SB_MSGID_WRAP_VALUE(HS_SEND_HK_MID),       0, 0},  /* Example of a message that wouldn't be sent */
-                {CFE_SB_MSGID_WRAP_VALUE(FM_SEND_HK_MID),       4, 0},
-                {CFE_SB_MSGID_WRAP_VALUE(DS_SEND_HK_MID),       4, 0},
-                {CFE_SB_MSGID_WRAP_VALUE(LC_SEND_HK_MID),       4, 0},
+SCH_LAB_ScheduleTable_t SCH_TBL_Structure = {
+    .TickRate = 1,
+    .Config   = {
+        {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_SEND_HK_MID), 4, 0},
+        {CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_SEND_HK_MID), 4, 0},
+        {CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_SEND_HK_MID), 4, 0},
+        {CFE_SB_MSGID_WRAP_VALUE(CFE_SB_SEND_HK_MID), 4, 0},
+        {CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_SEND_HK_MID), 4, 0},
+#ifdef HAVE_CI_LAB
+        {CFE_SB_MSGID_WRAP_VALUE(CI_LAB_SEND_HK_MID), 4, 0},
 #endif
-                                             }};
+#ifdef HAVE_TO_LAB
+        {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_SEND_HK_MID), 4, 0},
+#endif
+#ifdef HAVE_SAMPLE_APP
+        {CFE_SB_MSGID_WRAP_VALUE(SAMPLE_APP_SEND_HK_MID), 4, 0},
+#endif
+#ifdef HAVE_SC_APP
+        {CFE_SB_MSGID_WRAP_VALUE(SC_SEND_HK_MID), 4, 0},
+        {CFE_SB_MSGID_WRAP_VALUE(SC_1HZ_WAKEUP_MID), 1, 0}, /* Example of a 1hz packet */
+#endif
+#ifdef HAVE_HS_APP
+        {CFE_SB_MSGID_WRAP_VALUE(HS_SEND_HK_MID), 0, 0}, /* Example of a message that wouldn't be sent */
+#endif
+#ifdef HAVE_FM_APP
+        {CFE_SB_MSGID_WRAP_VALUE(FM_SEND_HK_MID), 4, 0},
+#endif
+#ifdef HAVE_DS_APP
+        {CFE_SB_MSGID_WRAP_VALUE(DS_SEND_HK_MID), 4, 0},
+#endif
+#ifdef HAVE_LC_APP
+        {CFE_SB_MSGID_WRAP_VALUE(LC_SEND_HK_MID), 4, 0},
+#endif
+    }};
 
 /*
 ** The macro below identifies:


### PR DESCRIPTION
**Describe the contribution**
Create an inclusion preprocessor macro for each app referred to in the subscription table, and only include that line if the app is present in the current configuration.

In particular, do not assume that sample_app will always be there.

Fixes #138

**Testing performed**
Build SCH_LAB without SAMPLE_APP and confirm successful

**Expected behavior changes**
Presence of other apps is not assumed/hardcoded in the table

**System(s) tested on**
Debian

**Additional context**
This should fix workflow errors where apps are built with SCH_LAB but without SAMPLE_APP.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
