### PR TITLE
Fix #141, Convert `int32` return codes and variables to `CFE_Status_t`

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -3,12 +3,12 @@ name: "CodeQL Analysis"
 on:
   push:
   pull_request:
-  
+
 jobs:
   codeql:
     name: Codeql
     uses: nasa/cFS/.github/workflows/codeql-reusable.yml@main
-    with: 
+    with:
       component-path: apps/sch_lab
       prep: 'make prep; make -C build/tools/elf2cfetbl'
       make: 'make -C build/native/default_cpu1/apps/sch_lab'

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -9,4 +9,3 @@ jobs:
   format-check:
     name: Run format check
     uses: nasa/cFS/.github/workflows/format-check.yml@main
-    

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,4 +9,3 @@ jobs:
   static-analysis:
     name: Run cppcheck
     uses: nasa/cFS/.github/workflows/static-analysis.yml@main
-    

--- a/fsw/platform_inc/sch_lab_table.h
+++ b/fsw/platform_inc/sch_lab_table.h
@@ -38,12 +38,10 @@
 
 #define SCH_MAX_MSG_WORDS 32
 
-#ifdef SOFTWARE_BIG_BIT_ORDER 
-#define SCH_PACK_32BIT(value) \
-(uint16)((value & 0xFFFF0000) >> 16), (uint16)(value & 0x0000FFFF) 
-#else 
-#define SCH_PACK_32BIT(value) \
-(uint16)(value & 0x0000FFFF), (uint16)((value & 0xFFFF0000) >> 16)
+#ifdef SOFTWARE_BIG_BIT_ORDER
+#define SCH_PACK_32BIT(value) (uint16)((value & 0xFFFF0000) >> 16), (uint16)(value & 0x0000FFFF)
+#else
+#define SCH_PACK_32BIT(value) (uint16)(value & 0x0000FFFF), (uint16)((value & 0xFFFF0000) >> 16)
 #endif
 
 /*

--- a/fsw/src/sch_lab_app.c
+++ b/fsw/src/sch_lab_app.c
@@ -66,11 +66,10 @@ typedef struct
 */
 SCH_LAB_GlobalData_t SCH_LAB_Global;
 
-
 /*
 ** Local Function Prototypes
 */
-int32 SCH_LAB_AppInit(void);
+CFE_Status_t SCH_LAB_AppInit(void);
 
 /*
 ** AppMain
@@ -155,10 +154,10 @@ void SCH_LAB_LocalTimerCallback(osal_id_t object_id, void *arg)
 /* Initialization                                                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 SCH_LAB_AppInit(void)
+CFE_Status_t SCH_LAB_AppInit(void)
 {
     int                           i, x;
-    int32                         Status;
+    CFE_Status_t                  Status;
     int32                         OsStatus;
     uint32                        TimerPeriod;
     osal_id_t                     TimeBaseId = OS_OBJECT_ID_UNDEFINED;
@@ -245,15 +244,15 @@ int32 SCH_LAB_AppInit(void)
         {
             /* Initialize the message with the length of the header + payload */
             CFE_MSG_Init(CFE_MSG_PTR(LocalStateEntry->CommandHeader), ConfigEntry->MessageID,
-                        sizeof(LocalStateEntry->CommandHeader) + ConfigEntry->PayloadLength);
+                         sizeof(LocalStateEntry->CommandHeader) + ConfigEntry->PayloadLength);
             CFE_MSG_SetFcnCode(CFE_MSG_PTR(LocalStateEntry->CommandHeader), ConfigEntry->FcnCode);
 
-            LocalStateEntry->PacketRate = ConfigEntry->PacketRate;
+            LocalStateEntry->PacketRate    = ConfigEntry->PacketRate;
             LocalStateEntry->PayloadLength = ConfigEntry->PayloadLength;
 
-            for (x =0; x < SCH_MAX_MSG_WORDS; x++)
+            for (x = 0; x < SCH_MAX_MSG_WORDS; x++)
             {
-                LocalStateEntry->MessageBuffer[x]=ConfigEntry->MessageBuffer[x];
+                LocalStateEntry->MessageBuffer[x] = ConfigEntry->MessageBuffer[x];
             }
         }
         ++ConfigEntry;

--- a/fsw/tables/sch_lab_table.c
+++ b/fsw/tables/sch_lab_table.c
@@ -52,7 +52,6 @@
 #include "lc_msgids.h"
 #endif
 
-
 /*
 ** Include headers for message IDs here
 */
@@ -70,43 +69,44 @@
 **  3. If the table grows too big, increase SCH_LAB_MAX_SCHEDULE_ENTRIES
 */
 
-SCH_LAB_ScheduleTable_t SCH_TBL_Structure = {.TickRate = 100,
-                                             .Config   = {
-                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_SEND_HK_MID), 100, 0},   /* Example of a 1hz packet */
-                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_SEND_HK_MID), 50, 0},
-                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_SEND_HK_MID), 98, 0},
-                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_SB_SEND_HK_MID), 97, 0},
-                                                 {CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_SEND_HK_MID), 96, 0},
+SCH_LAB_ScheduleTable_t SCH_TBL_Structure = {
+    .TickRate = 100,
+    .Config   = {
+        {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_SEND_HK_MID), 100, 0}, /* Example of a 1hz packet */
+        {CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_SEND_HK_MID), 50, 0},
+        {CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_SEND_HK_MID), 98, 0},
+        {CFE_SB_MSGID_WRAP_VALUE(CFE_SB_SEND_HK_MID), 97, 0},
+        {CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_SEND_HK_MID), 96, 0},
 
-                                            /* Example of including additional open source apps  */
-                                            #ifdef HAVE_CI_LAB
-                                                 {CFE_SB_MSGID_WRAP_VALUE(CI_LAB_SEND_HK_MID), 95, 0},
-                                            #endif
-                                            #ifdef HAVE_TO_LAB
-                                                 {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_SEND_HK_MID), 94, 0},
-                                            #endif
-                                            #ifdef HAVE_SAMPLE_APP
-                                                 {CFE_SB_MSGID_WRAP_VALUE(SAMPLE_APP_SEND_HK_MID), 93, 0},
-                                            #endif
-                                            #ifdef HAVE_SC
-                                                 {CFE_SB_MSGID_WRAP_VALUE(SC_SEND_HK_MID), 92, 0},
-                                                 {CFE_SB_MSGID_WRAP_VALUE(SC_1HZ_WAKEUP_MID), 91, 0},
-                                            #endif
-                                            #ifdef HAVE_HS
-                                                 {CFE_SB_MSGID_WRAP_VALUE(HS_SEND_HK_MID), 90, 0}, /* Example of a message that wouldn't be sent */
-                                            #endif
-                                            #ifdef HAVE_FM
-                                                 {CFE_SB_MSGID_WRAP_VALUE(FM_SEND_HK_MID), 101, 0},
-                                            #endif
-                                            #ifdef HAVE_DS
-                                                 {CFE_SB_MSGID_WRAP_VALUE(DS_SEND_HK_MID), 102, 0},
-                                            #endif
-                                            #ifdef HAVE_LC
-                                                {CFE_SB_MSGID_WRAP_VALUE(LC_SEND_HK_MID), 103, 0},
-                                                {CFE_SB_MSGID_WRAP_VALUE(LC_SAMPLE_AP_MID),     500, 0, 8, { 0, 175, 1 }},
-                                            #endif
+/* Example of including additional open source apps  */
+#ifdef HAVE_CI_LAB
+        {CFE_SB_MSGID_WRAP_VALUE(CI_LAB_SEND_HK_MID), 95, 0},
+#endif
+#ifdef HAVE_TO_LAB
+        {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_SEND_HK_MID), 94, 0},
+#endif
+#ifdef HAVE_SAMPLE_APP
+        {CFE_SB_MSGID_WRAP_VALUE(SAMPLE_APP_SEND_HK_MID), 93, 0},
+#endif
+#ifdef HAVE_SC
+        {CFE_SB_MSGID_WRAP_VALUE(SC_SEND_HK_MID), 92, 0},
+        {CFE_SB_MSGID_WRAP_VALUE(SC_1HZ_WAKEUP_MID), 91, 0},
+#endif
+#ifdef HAVE_HS
+        {CFE_SB_MSGID_WRAP_VALUE(HS_SEND_HK_MID), 90, 0}, /* Example of a message that wouldn't be sent */
+#endif
+#ifdef HAVE_FM
+        {CFE_SB_MSGID_WRAP_VALUE(FM_SEND_HK_MID), 101, 0},
+#endif
+#ifdef HAVE_DS
+        {CFE_SB_MSGID_WRAP_VALUE(DS_SEND_HK_MID), 102, 0},
+#endif
+#ifdef HAVE_LC
+        {CFE_SB_MSGID_WRAP_VALUE(LC_SEND_HK_MID), 103, 0},
+        {CFE_SB_MSGID_WRAP_VALUE(LC_SAMPLE_AP_MID), 500, 0, 8, {0, 175, 1}},
+#endif
 
-                                             }};
+    }};
 
 /*
 ** The macro below identifies:


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #141 
  - `int32` return codes converted over to `CFE_Status_t`

edit: some formatting issues cropped up after a recent PR went through

**Testing performed**
GitHub CI actions all passing successfully.
Local testing with full cFS suite passing all tests and showing not change to coverage.

**Expected behavior changes**
No change to behavior.
`CFE_Status_t` is more expressive and improves consistency with cFE/cFS.

**Contributor Info**
Avi Weiss @thnkslprpt