### PR TITLE
Fix #148, Call `CFE_ES_ExitApp` with `RunStatus` rather than internal `status` variable

### DIFF
--- a/fsw/src/sch_lab_app.c
+++ b/fsw/src/sch_lab_app.c
@@ -142,7 +142,7 @@ void SCH_Lab_AppMain(void)
 
     } /* end while */
 
-    CFE_ES_ExitApp(Status);
+    CFE_ES_ExitApp(RunStatus);
 }
 
 void SCH_LAB_LocalTimerCallback(osal_id_t object_id, void *arg)


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #148
  - `CFE_ES_ExitApp` in `SCH_Lab_AppMain` is now called with `RunStatus` as the argument, rather than the internal `status` control variable

**Testing performed**
Tested locally to confirm [error path](https://github.com/nasa/cFE/blob/c1aa16ae647f6ec4b2f23175a120be29034b8462/modules/es/fsw/src/cfe_es_api.c#L352-L358) in `CFE_ES_ExitApp` no longer being executed.

**Expected behavior changes**
`CFE_ES_ExitApp` now runs without error when called from `SCH_Lab_AppMain`

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt