### PR TITLE
Fix #155, correct inclusion for SCH_LAB example table

### DIFF
--- a/fsw/tables/sch_lab_table.c
+++ b/fsw/tables/sch_lab_table.c
@@ -18,7 +18,10 @@
 
 #include "cfe_tbl_filedef.h" /* Required to obtain the CFE_TBL_FILEDEF macro definition */
 #include "sch_lab_tbl.h"
-#include "cfe_sb.h" /* Required to use the CFE_SB_MSGID_WRAP_VALUE macro */
+#include "cfe_sb_api_typedefs.h" /* Required to use the CFE_SB_MSGID_WRAP_VALUE macro */
+
+/* This is for the standard set of CFE core app MsgID values */
+#include "cfe_msgids.h"
 
 #ifdef HAVE_CI_LAB
 #include "ci_lab_msgids.h"


### PR DESCRIPTION
**Describe the contribution**
The SCH_LAB table references the CFE msgids but did not explicitly include this header.

Fixes #155

**Testing performed**
Build and test in conjunction with nasa/cfe#2474

**Expected behavior changes**
None

**System(s) tested on**
Debian

**Additional context**
Never noticed this issue because the `cfe_msgids.h` file had been gotten implicitly via one of the other headers.  That is not always guaranteed to happen.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.