### PR TITLE
Fix #147, updating sch_lab to use new versioning system.

### DIFF
--- a/fsw/src/sch_lab_app.c
+++ b/fsw/src/sch_lab_app.c
@@ -28,6 +28,7 @@
 
 #include "cfe.h"
 #include "cfe_msgids.h"
+#include "cfe_config.h"
 
 #include "sch_lab_perfids.h"
 #include "sch_lab_version.h"
@@ -159,6 +160,7 @@ CFE_Status_t SCH_LAB_AppInit(void)
     SCH_LAB_ScheduleTableEntry_t *ConfigEntry;
     SCH_LAB_StateEntry_t *        LocalStateEntry;
     void *                        TableAddr;
+    char                          VersionString[SCH_LAB_CFG_MAX_VERSION_STR_LEN];
 
     memset(&SCH_LAB_Global, 0, sizeof(SCH_LAB_Global));
 
@@ -298,7 +300,10 @@ CFE_Status_t SCH_LAB_AppInit(void)
         CFE_ES_WriteToSysLog("%s: OS_TimerSet failed:RC=%ld\n", __func__, (long)OsStatus);
     }
 
-    OS_printf("SCH Lab Initialized.%s\n", SCH_LAB_VERSION_STRING);
+    CFE_Config_GetVersionString(VersionString, SCH_LAB_CFG_MAX_VERSION_STR_LEN, "SCH Lab",
+                          SCH_LAB_VERSION, SCH_LAB_BUILD_CODENAME, SCH_LAB_LAST_OFFICIAL);
+
+    OS_printf("SCH Lab Initialized.%s\n", VersionString);
 
     return CFE_SUCCESS;
 }

--- a/fsw/src/sch_lab_version.h
+++ b/fsw/src/sch_lab_version.h
@@ -25,16 +25,22 @@
  */
 
 /* Development Build Macro Definitions */
-#define SCH_LAB_BUILD_NUMBER 75 /*!< Development Build: Number of commits since baseline */
-#define SCH_LAB_BUILD_BASELINE \
-    "v2.5.0-rc4" /*!< Development Build: git tag that is the base for the current development */
+#define SCH_LAB_BUILD_NUMBER     75 /*!< Development Build: Number of commits since baseline */
+#define SCH_LAB_BUILD_BASELINE   "equuleus-rc1" /*!< Development Build: git tag that is the base for the current development */
+#define SCH_LAB_BUILD_DEV_CYCLE  "equuleus-rc2" /**< @brief Development: Release name for current development cycle */
+#define SCH_LAB_BUILD_CODENAME   "Equuleus" /**< @brief: Development: Code name for the current build */
 
 /*
  * Version Macros, see \ref cfsversions for definitions.
  */
 #define SCH_LAB_MAJOR_VERSION 2  /*!< @brief Major version number */
 #define SCH_LAB_MINOR_VERSION 3  /*!< @brief Minor version number */
-#define SCH_LAB_REVISION      99 /*!< @brief Revision version number. Value of 99 indicates a development version.*/
+#define SCH_LAB_REVISION      0  /*!< @brief Revision version number. Value of 0 indicates a development version.*/
+
+/**
+ * @brief Last official release.
+ */
+#define SCH_LAB_LAST_OFFICIAL "v2.3.0"
 
 /*!
  * @brief Mission revision.
@@ -54,12 +60,12 @@
  */
 #define SCH_LAB_VERSION SCH_LAB_BUILD_BASELINE "+dev" SCH_LAB_STR(SCH_LAB_BUILD_NUMBER)
 
-/*! @brief Development Build Version String.
- * @details Reports the current development build's baseline, number, and name. Also includes a note about the latest
- * official version. @n See @ref cfsversions for format differences between development and release versions.
+/**
+ * @brief Max Version String length.
+ * 
+ * Maximum length that an SCH LAB version string can be.
+ * 
  */
-#define SCH_LAB_VERSION_STRING                    \
-    " SCH Lab DEVELOPMENT BUILD " SCH_LAB_VERSION \
-    ", Last Official Release: v2.3.0" /* For full support please use this version */
+#define SCH_LAB_CFG_MAX_VERSION_STR_LEN 256
 
 #endif


### PR DESCRIPTION
**Describe the contribution**
Fixes #147.

**Testing performed**
Workflows were run.

**Expected behavior changes**
No behavior changes, however the following changes were made to the versioning system:
1. Build Baseline is set to "equuleus-rc1"
2. Mission Revision is set to to 00
3. "SCH_LAB_BUILD_DEV_CYCLE" macro has been defined
4. Version String has been removed, and all references to it replaced with the Build Baseline/Codename

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Dylan Z. Baker/NASA GSFC