### PR TITLE
Fix #162, CFE_TIME_1HZ_CMD_MID deprecated

### DIFF
--- a/fsw/src/sch_lab_app.c
+++ b/fsw/src/sch_lab_app.c
@@ -285,7 +285,7 @@ CFE_Status_t SCH_LAB_AppInit(void)
         OS_printf("SCH Error creating pipe!\n");
     }
 
-    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_1HZ_CMD_MID), SCH_LAB_Global.CmdPipe);
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_ONEHZ_CMD_MID), SCH_LAB_Global.CmdPipe);
     if (Status != CFE_SUCCESS)
     {
         OS_printf("SCH Error subscribing to 1hz!\n");


### PR DESCRIPTION
**Describe the contribution**
- Fix #162

**Testing performed**
CI

**Expected behavior changes**
Works with CFE_OMIT_DEPRECATED

**System(s) tested on**
CI

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC