### PR TITLE
Open Source Draco Release

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -2,7 +2,15 @@ name: "CodeQL Analysis"
 
 on:
   push:
+    branches:
+      - dev
+      - main
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+  workflow_dispatch:
 
 jobs:
   codeql:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -2,8 +2,11 @@ name: Format Check
 
 # Run on all push and pull requests
 on:
-  push:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 jobs:
   format-check:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,7 +3,15 @@ name: Static Analysis
 # Run on all push and pull requests
 on:
   push:
+    branches:
+      - dev
+      - main
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+  workflow_dispatch:
 
 jobs:
   static-analysis:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,7 @@
-cmake_minimum_required(VERSION 3.5)
 project(CFS_SCH_LAB C)
-
-# These references are specifically needed for the table build
-# it is easiest to add them as directory properties so they won't
-# be considered include directories for TO_LAB itself.  Each one
-# gets a macro for conditional inclusion in the subscription table.
-foreach(EXT_APP ci_lab to_lab sample_app sc hs lc ds fm)
-  list (FIND TGTSYS_${SYSVAR}_APPS ${EXT_APP} HAVE_APP)
-  if (HAVE_APP GREATER_EQUAL 0)
-    include_directories($<TARGET_PROPERTY:${EXT_APP},INTERFACE_INCLUDE_DIRECTORIES>)
-    string(TOUPPER "HAVE_${EXT_APP}" APP_MACRO)
-    add_definitions(-D${APP_MACRO})
-  endif()
-endforeach()
 
 # Create the app module
 add_cfe_app(sch_lab fsw/src/sch_lab_app.c)
 add_cfe_tables(sch_lab fsw/tables/sch_lab_table.c)
+
+target_include_directories(sch_lab PUBLIC fsw/inc)

--- a/arch_build.cmake
+++ b/arch_build.cmake
@@ -10,15 +10,10 @@
 
 # The list of header files that control the SCH_LAB configuration
 set(SCH_LAB_PLATFORM_CONFIG_FILE_LIST
+  sch_lab_internal_cfg_values.h
+  sch_lab_platform_cfg.h
   sch_lab_perfids.h
 )
 
-# Create wrappers around the all the config header files
-# This makes them individually overridable by the missions, without modifying
-# the distribution default copies
-foreach(SCH_LAB_CFGFILE ${SCH_LAB_PLATFORM_CONFIG_FILE_LIST})
-  generate_config_includefile(
-    FILE_NAME           "${SCH_LAB_CFGFILE}"
-    FALLBACK_FILE       "${CMAKE_CURRENT_LIST_DIR}/config/default_${SCH_LAB_CFGFILE}"
-  )
-endforeach()
+generate_configfile_set(${SCH_LAB_PLATFORM_CONFIG_FILE_LIST})
+

--- a/config/default_sch_lab_interface_cfg_values.h
+++ b/config/default_sch_lab_interface_cfg_values.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -18,29 +18,21 @@
 
 /**
  * @file
+ *   SCH_LAB Application Public Definitions
  *
- * CFS SCH_LAB Application Mission Configuration Header File
+ * This provides default values for configurable items that affect
+ * the interface(s) of this module.  This includes the CMD/TLM message
+ * interface, tables definitions, and any other data products that
+ * serve to exchange information with other entities.
  *
- * This is a compatibility header for the "mission_cfg.h" file that has
- * traditionally provided public config definitions for each CFS app.
- *
- * @note This file may be overridden/superceded by mission-provided defintions
+ * @note This file may be overridden/superceded by mission-provided definitions
  * either by overriding this header or by generating definitions from a command/data
  * dictionary tool.
  */
-#ifndef SCH_LAB_INTERFACE_CFG_H
-#define SCH_LAB_INTERFACE_CFG_H
+#ifndef DEFAULT_SCH_LAB_INTERFACE_CFG_VALUES_H
+#define DEFAULT_SCH_LAB_INTERFACE_CFG_VALUES_H
 
-/**
- * @brief The maximum number of schedule table entries
- */
-#define SCH_LAB_MAX_SCHEDULE_ENTRIES 32
+/* Use the default configuration value for all */
+#define SCH_LAB_MISSION_CFGVAL(x) DEFAULT_SCH_LAB_MISSION_##x
 
-/**
- * @brief The maximum number of arguments to each schedule message entry
- *
- * This is allocated in units of 16 bit words.
- */
-#define SCH_LAB_MAX_ARGS_PER_ENTRY 32
-
-#endif /* SCH_LAB_INTERFACE_CFG_H */
+#endif

--- a/config/default_sch_lab_internal_cfg_values.h
+++ b/config/default_sch_lab_internal_cfg_values.h
@@ -18,24 +18,21 @@
 
 /**
  * @file
- *   Specification for the CFS SCH_LAB table encapsulation structures
+ *   SCH_LAB Application Private Config Definitions
  *
- * Provides default definitions for SCH_LAB table structures
+ * This provides default values for configurable items that are internal
+ * to this module and do NOT affect the interface(s) of this module.  Changes
+ * to items in this file only affect the local module and will be transparent
+ * to external entities that are using the public interface(s).
  *
  * @note This file may be overridden/superceded by mission-provided definitions
  * either by overriding this header or by generating definitions from a command/data
  * dictionary tool.
  */
-#ifndef DEFAULT_SCH_LAB_TBLSTRUCT_H
-#define DEFAULT_SCH_LAB_TBLSTRUCT_H
+#ifndef DEFAULT_SCH_LAB_INTERNAL_CFG_VALUES_H
+#define DEFAULT_SCH_LAB_INTERNAL_CFG_VALUES_H
 
-#include "sch_lab_mission_cfg.h"
-#include "sch_lab_tbldefs.h"
-
-typedef struct
-{
-    uint32                       TickRate; /* Ticks per second to configure for timer (0=default) */
-    SCH_LAB_ScheduleTableEntry_t Config[SCH_LAB_MISSION_MAX_SCHEDULE_ENTRIES];
-} SCH_LAB_ScheduleTable_t;
+/* Use the default configuration value for all */
+#define SCH_LAB_PLATFORM_CFGVAL(x) DEFAULT_SCH_LAB_PLATFORM_##x
 
 #endif

--- a/config/default_sch_lab_mission_cfg.h
+++ b/config/default_sch_lab_mission_cfg.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -24,13 +24,27 @@
  * This is a compatibility header for the "mission_cfg.h" file that has
  * traditionally provided public config definitions for each CFS app.
  *
- * @note This file may be overridden/superceded by mission-provided defintions
+ * @note This file may be overridden/superceded by mission-provided definitions
  * either by overriding this header or by generating definitions from a command/data
  * dictionary tool.
  */
-#ifndef SCH_LAB_MISSION_CFG_H
-#define SCH_LAB_MISSION_CFG_H
+#ifndef DEFAULT_SCH_LAB_MISSION_CFG_H
+#define DEFAULT_SCH_LAB_MISSION_CFG_H
 
-#include "sch_lab_interface_cfg.h"
+#include "sch_lab_interface_cfg_values.h"
 
-#endif /* SCH_LAB_MISSION_CFG_H */
+/**
+ * @brief The maximum number of schedule table entries
+ */
+#define SCH_LAB_MISSION_MAX_SCHEDULE_ENTRIES         SCH_LAB_MISSION_CFGVAL(MAX_SCHEDULE_ENTRIES)
+#define DEFAULT_SCH_LAB_MISSION_MAX_SCHEDULE_ENTRIES 32
+
+/**
+ * @brief The maximum number of arguments to each schedule message entry
+ *
+ * This is allocated in units of 16 bit words.
+ */
+#define SCH_LAB_MISSION_MAX_ARGS_PER_ENTRY         SCH_LAB_MISSION_CFGVAL(MAX_ARGS_PER_ENTRY)
+#define DEFAULT_SCH_LAB_MISSION_MAX_ARGS_PER_ENTRY 32
+
+#endif /* DEFAULT_SCH_LAB_MISSION_CFG_H */

--- a/config/default_sch_lab_perfids.h
+++ b/config/default_sch_lab_perfids.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -23,8 +23,8 @@
  * These ID values need to be unique across a CFS deployment, so they may be customized
  * as needed to avoid collision with other apps.
  */
-#ifndef SCH_LAB_PERFIDS_H
-#define SCH_LAB_PERFIDS_H
+#ifndef DEFAULT_SCH_LAB_PERFIDS_H
+#define DEFAULT_SCH_LAB_PERFIDS_H
 
 #define SCH_LAB_MAIN_TASK_PERF_ID 36
 

--- a/config/default_sch_lab_platform_cfg.h
+++ b/config/default_sch_lab_platform_cfg.h
@@ -18,24 +18,20 @@
 
 /**
  * @file
- *   Specification for the CFS SCH_LAB table encapsulation structures
  *
- * Provides default definitions for SCH_LAB table structures
+ * CFS SCH_LAB Application Mission Configuration Header File
+ *
+ * This is a compatibility header for the "mission_cfg.h" file that has
+ * traditionally provided public config definitions for each CFS app.
  *
  * @note This file may be overridden/superceded by mission-provided definitions
  * either by overriding this header or by generating definitions from a command/data
  * dictionary tool.
  */
-#ifndef DEFAULT_SCH_LAB_TBLSTRUCT_H
-#define DEFAULT_SCH_LAB_TBLSTRUCT_H
+#ifndef DEFAULT_SCH_LAB_PLATFORM_CFG_H
+#define DEFAULT_SCH_LAB_PLATFORM_CFG_H
 
 #include "sch_lab_mission_cfg.h"
-#include "sch_lab_tbldefs.h"
+#include "sch_lab_internal_cfg.h"
 
-typedef struct
-{
-    uint32                       TickRate; /* Ticks per second to configure for timer (0=default) */
-    SCH_LAB_ScheduleTableEntry_t Config[SCH_LAB_MISSION_MAX_SCHEDULE_ENTRIES];
-} SCH_LAB_ScheduleTable_t;
-
-#endif
+#endif /* DEFAULT_SCH_LAB_PLATFORM_CFG_H */

--- a/config/default_sch_lab_tbl.h
+++ b/config/default_sch_lab_tbl.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -24,25 +24,10 @@
  *   Constants and enumerated types related to these table structures
  *   are defined in sch_lab_tbldefs.h.
  */
-#ifndef SCH_LAB_TBL_H
-#define SCH_LAB_TBL_H
+#ifndef DEFAULT_SCH_LAB_TBL_H
+#define DEFAULT_SCH_LAB_TBL_H
 
 #include "sch_lab_tbldefs.h"
 #include "sch_lab_tblstruct.h"
-
-/*
-** Defines
-*/
-#ifdef SOFTWARE_BIG_BIT_ORDER
-#define SCH_PACK_32BIT(value) (uint16)((value & 0xFFFF0000) >> 16), (uint16)(value & 0x0000FFFF)
-#else
-#define SCH_PACK_32BIT(value) (uint16)(value & 0x0000FFFF), (uint16)((value & 0xFFFF0000) >> 16)
-#endif
-
-/*
- * There is no extra encapsulation here, this header only
- * defines the default file name to use for the SCH table
- */
-#define SCH_LAB_TBL_DEFAULT_FILE "/cf/sch_lab_table.tbl"
 
 #endif

--- a/config/default_sch_lab_tbldefs.h
+++ b/config/default_sch_lab_tbldefs.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -25,8 +25,8 @@
  * of the application.  Any modification to these structures will likely need
  * a correpsonding update to the source code.
  */
-#ifndef SCH_LAB_TBLDEFS_H
-#define SCH_LAB_TBLDEFS_H
+#ifndef DEFAULT_SCH_LAB_TBLDEFS_H
+#define DEFAULT_SCH_LAB_TBLDEFS_H
 
 #include "cfe_sb_extern_typedefs.h" /* for CFE_SB_MsgId_t */
 #include "cfe_msg_api_typedefs.h"   /* For CFE_MSG_FcnCode_t */
@@ -35,15 +35,24 @@
 #include "sch_lab_mission_cfg.h"
 
 /*
+** Defines
+*/
+#ifdef SOFTWARE_BIG_BIT_ORDER
+#define SCH_PACK_32BIT(value) (uint16)((value & 0xFFFF0000) >> 16), (uint16)(value & 0x0000FFFF)
+#else
+#define SCH_PACK_32BIT(value) (uint16)(value & 0x0000FFFF), (uint16)((value & 0xFFFF0000) >> 16)
+#endif
+
+/*
 ** Typedefs
 */
 typedef struct
 {
-    CFE_SB_MsgId_t    MessageID;                                 /* Message ID for the table entry */
-    uint32            PacketRate;                                /* Rate: Send packet every N ticks */
-    CFE_MSG_FcnCode_t FcnCode;                                   /* Command/Function code to set */
-    uint16            PayloadLength;                             /* Length of additional command args */
-    uint16            MessageBuffer[SCH_LAB_MAX_ARGS_PER_ENTRY]; /* Command args in 16 bit words */
+    CFE_SB_MsgId_t    MessageID;                                         /* Message ID for the table entry */
+    uint32            PacketRate;                                        /* Rate: Send packet every N ticks */
+    CFE_MSG_FcnCode_t FcnCode;                                           /* Command/Function code to set */
+    uint16            PayloadLength;                                     /* Length of additional command args */
+    uint16            MessageBuffer[SCH_LAB_MISSION_MAX_ARGS_PER_ENTRY]; /* Command args in 16 bit words */
 } SCH_LAB_ScheduleTableEntry_t;
 
 #endif

--- a/eds/sch_lab.xml
+++ b/eds/sch_lab.xml
@@ -57,5 +57,16 @@
         </EntryList>
       </ContainerDataType>
     </DataTypeSet>
+    <ComponentSet>
+      <Component name="Application">
+        <RequiredInterfaceSet>
+          <Interface name="Schedule" shortDescription="Scheduler Table" type="CFE_TBL/Table">
+            <GenericTypeMapSet>
+              <GenericTypeMap name="TableDataType" type="ScheduleTable" />
+            </GenericTypeMapSet>
+          </Interface>
+        </RequiredInterfaceSet>
+      </Component>
+    </ComponentSet>
   </Package>
 </PackageFile>

--- a/fsw/inc/sch_lab_interface_cfg.h
+++ b/fsw/inc/sch_lab_interface_cfg.h
@@ -18,24 +18,33 @@
 
 /**
  * @file
- *   Specification for the CFS SCH_LAB table encapsulation structures
  *
- * Provides default definitions for SCH_LAB table structures
+ * CFS SCH_LAB Application Mission Configuration Header File
+ *
+ * This is a compatibility header for the "mission_cfg.h" file that has
+ * traditionally provided public config definitions for each CFS app.
  *
  * @note This file may be overridden/superceded by mission-provided definitions
  * either by overriding this header or by generating definitions from a command/data
  * dictionary tool.
  */
-#ifndef DEFAULT_SCH_LAB_TBLSTRUCT_H
-#define DEFAULT_SCH_LAB_TBLSTRUCT_H
+#ifndef SCH_LAB_INTERFACE_CFG_H
+#define SCH_LAB_INTERFACE_CFG_H
 
-#include "sch_lab_mission_cfg.h"
-#include "sch_lab_tbldefs.h"
+#include "sch_lab_interface_cfg_values.h"
 
-typedef struct
-{
-    uint32                       TickRate; /* Ticks per second to configure for timer (0=default) */
-    SCH_LAB_ScheduleTableEntry_t Config[SCH_LAB_MISSION_MAX_SCHEDULE_ENTRIES];
-} SCH_LAB_ScheduleTable_t;
+/**
+ * @brief The maximum number of schedule table entries
+ */
+#define SCH_LAB_MISSION_MAX_SCHEDULE_ENTRIES         SCH_LAB_MISSION_CFGVAL(MAX_SCHEDULE_ENTRIES)
+#define DEFAULT_SCH_LAB_MISSION_MAX_SCHEDULE_ENTRIES 32
 
-#endif
+/**
+ * @brief The maximum number of arguments to each schedule message entry
+ *
+ * This is allocated in units of 16 bit words.
+ */
+#define SCH_LAB_MISSION_MAX_ARGS_PER_ENTRY         SCH_LAB_MISSION_CFGVAL(MAX_ARGS_PER_ENTRY)
+#define DEFAULT_SCH_LAB_MISSION_MAX_ARGS_PER_ENTRY 32
+
+#endif /* SCH_LAB_MISSION_CFG_H */

--- a/fsw/inc/sch_lab_internal_cfg.h
+++ b/fsw/inc/sch_lab_internal_cfg.h
@@ -18,24 +18,27 @@
 
 /**
  * @file
- *   Specification for the CFS SCH_LAB table encapsulation structures
  *
- * Provides default definitions for SCH_LAB table structures
+ * CFS SCH_LAB Application Mission Configuration Header File
+ *
+ * This is a compatibility header for the "mission_cfg.h" file that has
+ * traditionally provided public config definitions for each CFS app.
  *
  * @note This file may be overridden/superceded by mission-provided definitions
  * either by overriding this header or by generating definitions from a command/data
  * dictionary tool.
  */
-#ifndef DEFAULT_SCH_LAB_TBLSTRUCT_H
-#define DEFAULT_SCH_LAB_TBLSTRUCT_H
+#ifndef SCH_LAB_INTERNAL_CFG_H
+#define SCH_LAB_INTERNAL_CFG_H
 
 #include "sch_lab_mission_cfg.h"
-#include "sch_lab_tbldefs.h"
+#include "sch_lab_internal_cfg_values.h"
 
-typedef struct
-{
-    uint32                       TickRate; /* Ticks per second to configure for timer (0=default) */
-    SCH_LAB_ScheduleTableEntry_t Config[SCH_LAB_MISSION_MAX_SCHEDULE_ENTRIES];
-} SCH_LAB_ScheduleTable_t;
+/*
+ * There is no extra encapsulation here, this header only
+ * defines the default file name to use for the SCH table
+ */
+#define SCH_LAB_PLATFORM_TBL_DEFAULT_FILE         SCH_LAB_PLATFORM_CFGVAL(TBL_DEFAULT_FILE)
+#define DEFAULT_SCH_LAB_PLATFORM_TBL_DEFAULT_FILE "/cf/sch_lab_table.tbl"
 
-#endif
+#endif /* SCH_LAB_INTERFACE_CFG_H */

--- a/fsw/src/sch_lab_app.c
+++ b/fsw/src/sch_lab_app.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -33,6 +33,7 @@
 #include "sch_lab_perfids.h"
 #include "sch_lab_version.h"
 #include "sch_lab_mission_cfg.h"
+#include "sch_lab_platform_cfg.h"
 #include "sch_lab_tbl.h"
 
 /*
@@ -41,7 +42,7 @@
 typedef struct
 {
     CFE_MSG_CommandHeader_t CommandHeader;
-    uint16                  MessageBuffer[SCH_LAB_MAX_ARGS_PER_ENTRY];
+    uint16                  MessageBuffer[SCH_LAB_MISSION_MAX_ARGS_PER_ENTRY];
     uint16                  PayloadLength;
     uint32                  PacketRate;
     uint32                  Counter;
@@ -49,7 +50,7 @@ typedef struct
 
 typedef struct
 {
-    SCH_LAB_StateEntry_t State[SCH_LAB_MAX_SCHEDULE_ENTRIES];
+    SCH_LAB_StateEntry_t State[SCH_LAB_MISSION_MAX_SCHEDULE_ENTRIES];
     osal_id_t            TimerId;
     osal_id_t            TimingSem;
     CFE_TBL_Handle_t     TblHandle;
@@ -119,7 +120,7 @@ void SCH_LAB_AppMain(void)
             */
             LocalStateEntry = SCH_LAB_Global.State;
 
-            for (i = 0; i < SCH_LAB_MAX_SCHEDULE_ENTRIES; i++)
+            for (i = 0; i < SCH_LAB_MISSION_MAX_SCHEDULE_ENTRIES; i++)
             {
                 if (LocalStateEntry->PacketRate != 0)
                 {
@@ -190,7 +191,7 @@ CFE_Status_t SCH_LAB_AppInit(void)
     /*
     ** Register tables with cFE and load default data
     */
-    Status = CFE_TBL_Register(&SCH_LAB_Global.TblHandle, "ScheduleTable", sizeof(SCH_LAB_ScheduleTable_t),
+    Status = CFE_TBL_Register(&SCH_LAB_Global.TblHandle, "Schedule", sizeof(SCH_LAB_ScheduleTable_t),
                               CFE_TBL_OPT_DEFAULT, NULL);
 
     if (Status != CFE_SUCCESS)
@@ -204,7 +205,7 @@ CFE_Status_t SCH_LAB_AppInit(void)
         /*
         ** Loading Table
         */
-        Status = CFE_TBL_Load(SCH_LAB_Global.TblHandle, CFE_TBL_SRC_FILE, SCH_LAB_TBL_DEFAULT_FILE);
+        Status = CFE_TBL_Load(SCH_LAB_Global.TblHandle, CFE_TBL_SRC_FILE, SCH_LAB_PLATFORM_TBL_DEFAULT_FILE);
         if (Status != CFE_SUCCESS)
         {
             CFE_ES_WriteToSysLog("SCH_LAB: Error Loading Table ScheduleTable, RC = 0x%08lX\n", (unsigned long)Status);
@@ -234,7 +235,7 @@ CFE_Status_t SCH_LAB_AppInit(void)
     LocalStateEntry = SCH_LAB_Global.State;
 
     /* Populate the CCSDS message and move the message content into the proper user data space. */
-    for (i = 0; i < SCH_LAB_MAX_SCHEDULE_ENTRIES; i++)
+    for (i = 0; i < SCH_LAB_MISSION_MAX_SCHEDULE_ENTRIES; i++)
     {
         if (ConfigEntry->PacketRate != 0)
         {
@@ -246,7 +247,7 @@ CFE_Status_t SCH_LAB_AppInit(void)
             LocalStateEntry->PacketRate    = ConfigEntry->PacketRate;
             LocalStateEntry->PayloadLength = ConfigEntry->PayloadLength;
 
-            for (x = 0; x < SCH_LAB_MAX_ARGS_PER_ENTRY; x++)
+            for (x = 0; x < SCH_LAB_MISSION_MAX_ARGS_PER_ENTRY; x++)
             {
                 LocalStateEntry->MessageBuffer[x] = ConfigEntry->MessageBuffer[x];
             }
@@ -300,8 +301,8 @@ CFE_Status_t SCH_LAB_AppInit(void)
         CFE_ES_WriteToSysLog("%s: OS_TimerSet failed:RC=%ld\n", __func__, (long)OsStatus);
     }
 
-    CFE_Config_GetVersionString(VersionString, SCH_LAB_CFG_MAX_VERSION_STR_LEN, "SCH Lab",
-                          SCH_LAB_VERSION, SCH_LAB_BUILD_CODENAME, SCH_LAB_LAST_OFFICIAL);
+    CFE_Config_GetVersionString(VersionString, SCH_LAB_CFG_MAX_VERSION_STR_LEN, "SCH Lab", SCH_LAB_VERSION,
+                                SCH_LAB_BUILD_CODENAME, SCH_LAB_LAST_OFFICIAL);
 
     OS_printf("SCH Lab Initialized.%s\n", VersionString);
 

--- a/fsw/src/sch_lab_version.h
+++ b/fsw/src/sch_lab_version.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -25,22 +25,22 @@
  */
 
 /* Development Build Macro Definitions */
-#define SCH_LAB_BUILD_NUMBER     29 /*!< Development Build: Number of commits since baseline */
-#define SCH_LAB_BUILD_BASELINE   "equuleus-rc1" /*!< Development Build: git tag that is the base for the current development */
-#define SCH_LAB_BUILD_DEV_CYCLE  "equuleus-rc2" /**< @brief Development: Release name for current development cycle */
-#define SCH_LAB_BUILD_CODENAME   "Equuleus" /**< @brief: Development: Code name for the current build */
+#define SCH_LAB_BUILD_NUMBER     0 /*!< Development Build: Number of commits since baseline */
+#define SCH_LAB_BUILD_BASELINE   "v7.0.0" /*!< Development Build: git tag that is the base for the current development */
+#define SCH_LAB_BUILD_DEV_CYCLE  "v7.0.0" /**< @brief Development: Release name for current development cycle */
+#define SCH_LAB_BUILD_CODENAME   "Draco" /**< @brief: Development: Code name for the current build */
 
 /*
  * Version Macros, see \ref cfsversions for definitions.
  */
-#define SCH_LAB_MAJOR_VERSION 2  /*!< @brief Major version number */
-#define SCH_LAB_MINOR_VERSION 3  /*!< @brief Minor version number */
+#define SCH_LAB_MAJOR_VERSION 7  /*!< @brief Major version number */
+#define SCH_LAB_MINOR_VERSION 0  /*!< @brief Minor version number */
 #define SCH_LAB_REVISION      0  /*!< @brief Revision version number. Value of 0 indicates a development version.*/
 
 /**
  * @brief Last official release.
  */
-#define SCH_LAB_LAST_OFFICIAL "v2.3.0"
+#define SCH_LAB_LAST_OFFICIAL "v7.0.0"
 
 /*!
  * @brief Mission revision.
@@ -49,7 +49,7 @@
  * Values 1-254 are reserved for mission use to denote patches/customizations as needed. NOTE: Reserving 0 and 0xFF for
  * cFS open-source development use (pending resolution of nasa/cFS#440)
  */
-#define SCH_LAB_MISSION_REV 0xFF
+#define SCH_LAB_MISSION_REV 0x0
 
 #define SCH_LAB_STR_HELPER(x) #x /*!< @brief Helper function to concatenate strings from integer macros */
 #define SCH_LAB_STR(x)        SCH_LAB_STR_HELPER(x) /*!< @brief Helper function to concatenate strings from integer macros */

--- a/fsw/tables/sch_lab_table.c
+++ b/fsw/tables/sch_lab_table.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -23,85 +23,34 @@
 /* This is for the standard set of CFE core app MsgID values */
 #include "cfe_msgids.h"
 
-#ifdef HAVE_CI_LAB
-#include "ci_lab_msgids.h"
-#endif
-
-#ifdef HAVE_TO_LAB
-#include "to_lab_msgids.h"
-#endif
-
-#ifdef HAVE_SAMPLE_APP
-#include "sample_app_msgids.h"
-#endif
-
-#ifdef HAVE_HS
-#include "hs_msgids.h"
-#endif
-
-#ifdef HAVE_FM
-#include "fm_msgids.h"
-#endif
-
-#ifdef HAVE_SC
-#include "sc_msgids.h"
-#endif
-
-#ifdef HAVE_DS
-#include "ds_msgids.h"
-#endif
-
-#ifdef HAVE_LC
-#include "lc_msgids.h"
-#endif
-
 /*
 ** SCH Lab schedule table
 ** When populating this table:
-**  1. The entire table is processed (SCH_LAB_MAX_SCHEDULE_ENTRIES) but entries with a
+**  1. The entire table is processed (SCH_LAB_MISSION_MAX_SCHEDULE_ENTRIES) but entries with a
 **     packet rate of 0 are skipped
 **  2. You can have commented out entries or entries with a packet rate of 0
-**  3. If the table grows too big, increase SCH_LAB_MAX_SCHEDULE_ENTRIES
+**  3. If the table grows too big, increase SCH_LAB_MISSION_MAX_SCHEDULE_ENTRIES
 */
 
-SCH_LAB_ScheduleTable_t SCH_LAB_ScheduleTable = {
+SCH_LAB_ScheduleTable_t Schedule = {
     .TickRate = 100,
     .Config   = {
-        {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_SEND_HK_MID), 100, 0}, /* Example of a 1hz packet */
+        /*
+        ** This is an empty default table.
+        ** Projects should override this default table with their own configurations.
+        ** Examples of cFE HK packet requests are shown in the comment below.
+        */
+        {CFE_SB_MSGID_RESERVED, 0, 0},
+        /*
+        ** Example of a cFE HK packet requests
+        {CFE_SB_MSGID_WRAP_VALUE(CFE_ES_SEND_HK_MID), 100, 0},
         {CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_SEND_HK_MID), 50, 0},
         {CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_SEND_HK_MID), 98, 0},
         {CFE_SB_MSGID_WRAP_VALUE(CFE_SB_SEND_HK_MID), 97, 0},
         {CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_SEND_HK_MID), 96, 0},
-
-/* Example of including additional open source apps  */
-#ifdef HAVE_CI_LAB
-        {CFE_SB_MSGID_WRAP_VALUE(CI_LAB_SEND_HK_MID), 95, 0},
-#endif
-#ifdef HAVE_TO_LAB
-        {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_SEND_HK_MID), 94, 0},
-#endif
-#ifdef HAVE_SAMPLE_APP
-        {CFE_SB_MSGID_WRAP_VALUE(SAMPLE_APP_SEND_HK_MID), 93, 0},
-#endif
-#ifdef HAVE_SC
-        {CFE_SB_MSGID_WRAP_VALUE(SC_SEND_HK_MID), 92, 0},
-        {CFE_SB_MSGID_WRAP_VALUE(SC_ONEHZ_WAKEUP_MID), 91, 0},
-#endif
-#ifdef HAVE_HS
-        {CFE_SB_MSGID_WRAP_VALUE(HS_SEND_HK_MID), 90, 0}, /* Example of a message that wouldn't be sent */
-#endif
-#ifdef HAVE_FM
-        {CFE_SB_MSGID_WRAP_VALUE(FM_SEND_HK_MID), 101, 0},
-#endif
-#ifdef HAVE_DS
-        {CFE_SB_MSGID_WRAP_VALUE(DS_SEND_HK_MID), 102, 0},
-#endif
-#ifdef HAVE_LC
-        {CFE_SB_MSGID_WRAP_VALUE(LC_SEND_HK_MID), 103, 0},
-        {CFE_SB_MSGID_WRAP_VALUE(LC_SAMPLE_AP_MID), 500, 0, 8, {0, 175, 1}},
-#endif
-
-    }};
+        */
+    }
+};
 
 /*
 ** The macro below identifies:
@@ -110,4 +59,4 @@ SCH_LAB_ScheduleTable_t SCH_LAB_ScheduleTable = {
 **    3) a brief description of the contents of the file image
 **    4) the desired name of the table image binary file that is cFE compatible
 */
-CFE_TBL_FILEDEF(SCH_LAB_ScheduleTable, SCH_LAB_APP.ScheduleTable, Schedule Lab MsgID Table, sch_lab_table.tbl)
+CFE_TBL_FILEDEF(Schedule, SCH_LAB.Schedule, Schedule Lab MsgID Table, sch_lab_table.tbl)

--- a/mission_build.cmake
+++ b/mission_build.cmake
@@ -10,35 +10,13 @@
 
 # The list of header files that control the SCH_LAB configuration
 set(SCH_LAB_MISSION_CONFIG_FILE_LIST
-  sch_lab_interface_cfg.h
+  sch_lab_interface_cfg_values.h
   sch_lab_mission_cfg.h
   sch_lab_perfids.h
-  sch_lab_tbldefs.h
   sch_lab_tbl.h
+  sch_lab_tbldefs.h
   sch_lab_tblstruct.h
 )
 
-if (CFE_EDS_ENABLED_BUILD)
+generate_configfile_set(${SCH_LAB_MISSION_CONFIG_FILE_LIST})
 
-  # In an EDS-based build, these files come generated from the EDS tool
-  set(SCH_LAB_CFGFILE_SRC_sch_lab_interface_cfg "sch_lab_eds_designparameters.h")
-  set(SCH_LAB_CFGFILE_SRC_sch_lab_tbldefs       "sch_lab_eds_typedefs.h")
-  set(SCH_LAB_CFGFILE_SRC_sch_lab_tblstruct     "sch_lab_eds_typedefs.h")
-
-endif(CFE_EDS_ENABLED_BUILD)
-
-# Create wrappers around the all the config header files
-# This makes them individually overridable by the missions, without modifying
-# the distribution default copies
-foreach(SCH_LAB_CFGFILE ${SCH_LAB_MISSION_CONFIG_FILE_LIST})
-  get_filename_component(CFGKEY "${SCH_LAB_CFGFILE}" NAME_WE)
-  if (DEFINED SCH_LAB_CFGFILE_SRC_${CFGKEY})
-    set(DEFAULT_SOURCE GENERATED_FILE "${SCH_LAB_CFGFILE_SRC_${CFGKEY}}")
-  else()
-    set(DEFAULT_SOURCE FALLBACK_FILE "${CMAKE_CURRENT_LIST_DIR}/config/default_${SCH_LAB_CFGFILE}")
-  endif()
-  generate_config_includefile(
-    FILE_NAME           "${SCH_LAB_CFGFILE}"
-    ${DEFAULT_SOURCE}
-  )
-endforeach()


### PR DESCRIPTION
[NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"](https://github.com/nasa/sch_lab/pull/171/commits/46044f9d0f58fe939ea1d182a854060e8d2e9e1d)
Batch update of latest cFS software release

Reflects commit d00958b63a8e6adc692d05bbf20474309b5fa090 from NASA internal development repo